### PR TITLE
fix: Sincronización de Select2 con Alpine.js en modales de turnos

### DIFF
--- a/resources/views/agenda/index.blade.php
+++ b/resources/views/agenda/index.blade.php
@@ -778,10 +778,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
 
-            // Sincronizar con Alpine.js
-            professionalSelect.on('change', function() {
-                const event = new CustomEvent('input', { bubbles: true });
-                this.dispatchEvent(event);
+            // Sincronizar con Alpine.js - Actualizar directamente el modelo
+            professionalSelect.on('change', function(e) {
+                const selectedValue = $(this).val();
+                // Buscar el componente Alpine.js y actualizar el form
+                const alpineComponent = Alpine.$data(document.querySelector('[x-data="appointmentModal()"]'));
+                if (alpineComponent) {
+                    alpineComponent.form.professional_id = selectedValue;
+                }
             });
 
             // Autofocus en el campo de búsqueda
@@ -838,10 +842,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
 
-            // Sincronizar con Alpine.js
-            patientSelect.on('change', function() {
-                const event = new CustomEvent('input', { bubbles: true });
-                this.dispatchEvent(event);
+            // Sincronizar con Alpine.js - Actualizar directamente el modelo
+            patientSelect.on('change', function(e) {
+                const selectedValue = $(this).val();
+                // Buscar el componente Alpine.js y actualizar el form
+                const alpineComponent = Alpine.$data(document.querySelector('[x-data="appointmentModal()"]'));
+                if (alpineComponent) {
+                    alpineComponent.form.patient_id = selectedValue;
+                }
             });
 
             // Autofocus en el campo de búsqueda

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -898,10 +898,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
 
-            // Sincronizar con Alpine.js
-            professionalSelect.on('change', function() {
-                const event = new CustomEvent('input', { bubbles: true });
-                this.dispatchEvent(event);
+            // Sincronizar con Alpine.js - Actualizar directamente el modelo
+            professionalSelect.on('change', function(e) {
+                const selectedValue = $(this).val();
+                // Buscar el componente Alpine.js y actualizar el form
+                const alpineComponent = Alpine.$data(document.querySelector('[x-data="appointmentsPage()"]'));
+                if (alpineComponent) {
+                    alpineComponent.form.professional_id = selectedValue;
+                }
             });
 
             // Prevenir que el clic en el dropdown cierre el modal
@@ -958,10 +962,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             });
 
-            // Sincronizar con Alpine.js
-            patientSelect.on('change', function() {
-                const event = new CustomEvent('input', { bubbles: true });
-                this.dispatchEvent(event);
+            // Sincronizar con Alpine.js - Actualizar directamente el modelo
+            patientSelect.on('change', function(e) {
+                const selectedValue = $(this).val();
+                // Buscar el componente Alpine.js y actualizar el form
+                const alpineComponent = Alpine.$data(document.querySelector('[x-data="appointmentsPage()"]'));
+                if (alpineComponent) {
+                    alpineComponent.form.patient_id = selectedValue;
+                }
             });
 
             // Prevenir que el clic en el dropdown cierre el modal y hacer autofocus


### PR DESCRIPTION
## Problema
Los selectores con búsqueda (Select2) no estaban enviando los IDs de profesional y paciente al crear turnos. El evento 'input' personalizado no sincronizaba correctamente con Alpine.js.

## Solución
- Acceso directo al componente Alpine.js usando Alpine.$data()
- Actualización directa de form.professional_id y form.patient_id
- Implementado en ambas vistas: appointments y agenda

## Archivos Corregidos
- resources/views/appointments/index.blade.php
- resources/views/agenda/index.blade.php

## Impacto
✅ Creación de turnos desde appointments: ahora toma profesional y paciente ✅ Creación de turnos desde agenda: ahora toma paciente correctamente ✅ Búsqueda por DNI funciona correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)