### PR TITLE
hotfix: Corregir referencias a columna 'type' eliminada en cash_movem…

### DIFF
--- a/app/Http/Controllers/LiquidationController.php
+++ b/app/Http/Controllers/LiquidationController.php
@@ -112,7 +112,7 @@ class LiquidationController extends Controller
             $professionalCommission = $professional->calculateCommission($totalCollected);
 
             // Obtener reintegros del día para este profesional (usando referencias polimórficas)
-            $refunds = CashMovement::where('type', 'expense')
+            $refunds = CashMovement::byType('expense')
                 ->where('reference_type', 'App\Models\Professional')
                 ->where('reference_id', $professional->id)
                 ->whereDate('movement_date', $date)

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -198,7 +198,7 @@ class ReportController extends Controller
                 $professionalCommission = $professional->calculateCommission($totalAmount);
 
                 // Obtener reintegros del día para este profesional (usando referencias polimórficas)
-                $refunds = \App\Models\CashMovement::where('type', 'expense')
+                $refunds = \App\Models\CashMovement::byType('expense')
                     ->where('reference_type', 'App\Models\Professional')
                     ->where('reference_id', $professional->id)
                     ->whereDate('movement_date', $selectedDate)
@@ -278,7 +278,7 @@ class ReportController extends Controller
         $professionalCommission = $professional->calculateCommission($totalAmount);
 
         // Obtener reintegros del día para este profesional (usando referencias polimórficas)
-        $refunds = \App\Models\CashMovement::where('type', 'expense')
+        $refunds = \App\Models\CashMovement::byType('expense')
             ->where('reference_type', 'App\Models\Professional')
             ->where('reference_id', $professionalId)
             ->whereDate('movement_date', $selectedDate)


### PR DESCRIPTION
…ents

Soluciona error de producción SQLSTATE[42S22]: Column not found: 1054 Unknown column 'type' in 'WHERE'.

La columna 'type' fue eliminada en la migración 2025_10_26_072215 y reemplazada por 'movement_type_id', pero existían referencias sin actualizar en los controladores.

Cambios:
- LiquidationController: Usar scope byType() en lugar de where('type')
- ReportController: Usar scope byType() en lugar de where('type')
- CashController: Reemplazar acceso directo a 'type' por relación movementType->code

🤖 Generated with [Claude Code](https://claude.com/claude-code)