### PR TITLE
hotfix: Corregir bug de overflow de meses en navegación de Agenda

### DIFF
--- a/app/Http/Controllers/AgendaController.php
+++ b/app/Http/Controllers/AgendaController.php
@@ -18,7 +18,9 @@ class AgendaController extends Controller
         $currentMonth = $request->get('month', now()->format('Y-m'));
         $selectedProfessional = $request->get('professional_id');
 
-        $date = Carbon::createFromFormat('Y-m', $currentMonth)->startOfMonth();
+        // Crear fecha con día 1 para evitar overflow en meses con menos días
+        // Bug: Si hoy es 31 y navegas a un mes con 30 días, Carbon hace overflow
+        $date = Carbon::createFromFormat('Y-m-d', $currentMonth . '-01');
         $startOfCalendar = $date->copy()->startOfWeek();
         $endOfCalendar = $date->copy()->endOfMonth()->endOfWeek();
 


### PR DESCRIPTION
Problema:
- Al navegar a meses con menos días que el día actual, Carbon generaba overflow
- Ejemplo: Estando en 31 de octubre, ir a septiembre (30 días) mostraba octubre
- El mismo problema ocurría con todos los meses de 30 días cuando el día actual era 31

Solución:
- Forzar día 1 al crear la fecha: Carbon::createFromFormat('Y-m-d', $month . '-01')
- Esto evita que Carbon intente crear fechas inválidas como "31 de noviembre"

Impacto:
- Navegación de meses funciona correctamente en todos los casos
- Ya no hay saltos de mes inesperados

🤖 Generated with [Claude Code](https://claude.com/claude-code)