### PR TITLE
feat: Recibos para ingresos manuales con numeración unificada

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ php artisan config:clear
 
 ### 🔄 Últimas versiones
 
-* **v2.5.11** (2025-11-04) – Arqueo de Caja: Reporte informativo sin cierre para verificación de efectivo.
+* **v2.5.11** (2025-11-04) – Arqueo de Caja + Recibos de Ingresos Manuales: Sistema unificado de numeración de recibos.
 * **v2.5.10** (2025-11-03) – Separación de gestión operativa de caja y reportes históricos con cards simplificadas.
 * **v2.5.9** (2025-11-02) – Sistema de entreturnos, anulación de pagos con trazabilidad completa.
 * **v2.5.8** (2025-10-29) – Corrección crítica de cálculo de balance en caja (eliminación de movement_date).

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -23,123 +23,67 @@ class PaymentController extends Controller
 
     public function index(Request $request)
     {
-        // Obtener pagos de pacientes
-        $paymentsQuery = Payment::with(['patient', 'paymentAppointments.appointment.professional']);
+        // Obtener todos los payments (ahora incluye pagos de pacientes e ingresos manuales)
+        $query = Payment::with(['patient', 'paymentAppointments.appointment.professional', 'createdBy']);
 
-        // Filtros para payments
+        // Filtros
         if ($request->filled('search')) {
             $search = $request->search;
-            $paymentsQuery->where(function($q) use ($search) {
+            $query->where(function($q) use ($search) {
                 $q->whereHas('patient', function ($subQ) use ($search) {
                     $subQ->where('first_name', 'like', "%{$search}%")
                         ->orWhere('last_name', 'like', "%{$search}%")
                         ->orWhere('dni', 'like', "%{$search}%");
-                })->orWhere('receipt_number', 'like', "%{$search}%");
+                })
+                ->orWhere('receipt_number', 'like', "%{$search}%")
+                ->orWhere('concept', 'like', "%{$search}%"); // Para buscar en ingresos manuales
             });
         }
 
         if ($request->filled('payment_type')) {
-            $paymentsQuery->where('payment_type', $request->payment_type);
+            $query->where('payment_type', $request->payment_type);
         }
 
         if ($request->filled('payment_method')) {
-            $paymentsQuery->where('payment_method', $request->payment_method);
+            $query->where('payment_method', $request->payment_method);
         }
 
         if ($request->filled('liquidation_status')) {
-            $paymentsQuery->where('liquidation_status', $request->liquidation_status);
+            $query->where('liquidation_status', $request->liquidation_status);
         }
 
         if ($request->filled('date_from')) {
-            $paymentsQuery->whereDate('payment_date', '>=', $request->date_from);
+            $query->whereDate('payment_date', '>=', $request->date_from);
         }
 
         if ($request->filled('date_to')) {
-            $paymentsQuery->whereDate('payment_date', '<=', $request->date_to);
+            $query->whereDate('payment_date', '<=', $request->date_to);
         }
 
-        $payments = $paymentsQuery->get()->map(function ($payment) {
-            $payment->entry_type = 'payment';
-            $payment->sort_date = $payment->payment_date;
-            return $payment;
-        });
-
-        // Obtener ingresos manuales (CashMovements de categoría income_detail)
-        $incomeQuery = CashMovement::with(['movementType', 'user', 'reference'])
-            ->whereHas('movementType', function($q) {
-                $q->where('category', 'income_detail')
-                  ->whereNotIn('code', ['patient_payment', 'cash_opening', 'cash_closing']);
-            });
-
-        // Filtros para ingresos manuales
-        if ($request->filled('search')) {
-            $search = $request->search;
-            $incomeQuery->where('description', 'like', "%{$search}%");
-        }
-
-        if ($request->filled('date_from')) {
-            $incomeQuery->whereDate('created_at', '>=', $request->date_from);
-        }
-
-        if ($request->filled('date_to')) {
-            $incomeQuery->whereDate('created_at', '<=', $request->date_to);
-        }
-
-        $incomes = $incomeQuery->get()->map(function ($income) {
-            $income->entry_type = 'income';
-            $income->sort_date = $income->created_at;
-            // Generar receipt_number para ingresos
-            $income->receipt_number = date('Ym', strtotime($income->created_at)) . str_pad($income->id, 4, '0', STR_PAD_LEFT);
-            return $income;
-        });
-
-        // Combinar y ordenar ambas colecciones
-        $allEntries = $payments->concat($incomes)
-            ->sortByDesc('sort_date')
-            ->values();
-
-        // Paginar manualmente
-        $page = $request->get('page', 1);
-        $perPage = 15;
-        $total = $allEntries->count();
-        $entries = $allEntries->slice(($page - 1) * $perPage, $perPage)->values();
-
-        $paginator = new \Illuminate\Pagination\LengthAwarePaginator(
-            $entries,
-            $total,
-            $perPage,
-            $page,
-            ['path' => $request->url(), 'query' => $request->query()]
-        );
-
-        // Estadísticas (incluir ingresos manuales)
+        // Estadísticas
         $stats = [
-            'total' => Payment::count() + CashMovement::whereHas('movementType', function($q) {
-                $q->where('category', 'income_detail')
-                  ->whereNotIn('code', ['patient_payment', 'cash_opening', 'cash_closing']);
-            })->count(),
-            'total_amount' => Payment::sum('amount') + CashMovement::whereHas('movementType', function($q) {
-                $q->where('category', 'income_detail')
-                  ->whereNotIn('code', ['patient_payment', 'cash_opening', 'cash_closing']);
-            })->sum('amount'),
+            'total' => Payment::count(),
+            'total_amount' => Payment::sum('amount'),
             'total_transfers' => Payment::where('payment_method', 'transfer')->count(),
             'total_cash' => Payment::where('payment_method', 'cash')->count(),
             'pending_liquidation' => Payment::where('liquidation_status', 'pending')->count(),
             'liquidated' => Payment::where('liquidation_status', 'liquidated')->count(),
         ];
 
+        $payments = $query->orderBy('payment_date', 'desc')
+            ->orderBy('created_at', 'desc')
+            ->paginate(15)
+            ->withQueryString();
+
         if ($request->ajax()) {
             return response()->json([
                 'success' => true,
-                'payments' => $paginator,
+                'payments' => $payments,
                 'stats' => $stats,
             ]);
         }
 
-        return view('payments.index', [
-            'payments' => $paginator,
-            'stats' => $stats
-        ]);
+        return view('payments.index', compact('payments', 'stats'));
     }
 
     public function create(Request $request)

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -22,6 +22,7 @@ class Payment extends Model
         'concept',
         'receipt_number',
         'created_by',
+        'income_category', // Para ingresos manuales (código del MovementType)
     ];
 
     protected $casts = [

--- a/database/migrations/2025_11_07_052638_make_patient_id_nullable_in_payments_table.php
+++ b/database/migrations/2025_11_07_052638_make_patient_id_nullable_in_payments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            // Hacer patient_id nullable para soportar ingresos manuales
+            $table->foreignId('patient_id')->nullable()->change();
+
+            // Agregar campo para almacenar el tipo de ingreso manual (si aplica)
+            $table->string('income_category')->nullable()->after('payment_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            // Revertir patient_id a no nullable
+            $table->foreignId('patient_id')->nullable(false)->change();
+
+            // Eliminar campo income_category
+            $table->dropColumn('income_category');
+        });
+    }
+};

--- a/resources/views/cash/manual-income-form.blade.php
+++ b/resources/views/cash/manual-income-form.blade.php
@@ -357,7 +357,7 @@ function incomeForm() {
 
                 if (response.ok && result.success) {
                     // Preguntar si desea imprimir el recibo
-                    if (result.cash_movement_id) {
+                    if (result.payment_id) {
                         const printReceipt = await SystemModal.confirm(
                             'Imprimir recibo',
                             '¿Desea imprimir el recibo ahora?',
@@ -366,7 +366,7 @@ function incomeForm() {
                         );
 
                         if (printReceipt) {
-                            window.open(`/cash/income-receipt/${result.cash_movement_id}?print=1`, '_blank');
+                            window.open(`/cash/income-receipt/${result.payment_id}?print=1`, '_blank');
                         }
                     }
 

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -220,7 +220,7 @@
                         </thead>
                         <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-600">
                             @forelse($payments as $payment)
-                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200 {{ $payment->entry_type === 'income' ? 'bg-green-50/50 dark:bg-green-900/10' : '' }}">
+                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200 {{ $payment->payment_type === 'manual_income' ? 'bg-green-50/50 dark:bg-green-900/10' : '' }}">
                                     <!-- Recibo -->
                                     <td class="px-3 py-2">
                                         <div class="text-sm font-mono text-gray-900 dark:text-white">{{ $payment->receipt_number }}</div>
@@ -228,36 +228,29 @@
 
                                     <!-- Paciente / De -->
                                     <td class="px-3 py-2">
-                                        @if($payment->entry_type === 'payment')
+                                        @if($payment->payment_type !== 'manual_income')
                                             <div class="text-sm font-medium text-gray-900 dark:text-white">{{ $payment->patient->full_name }}</div>
                                             <div class="text-sm text-gray-500 dark:text-gray-400">DNI: {{ $payment->patient->dni }}</div>
                                         @else
                                             {{-- Ingreso Manual --}}
                                             <div class="text-sm font-medium text-gray-900 dark:text-white">
-                                                @if($payment->reference_type === 'App\\Models\\Professional' && $payment->reference)
-                                                    Dr. {{ $payment->reference->full_name }}
-                                                @else
-                                                    Ingreso Manual
-                                                @endif
+                                                Ingreso Manual
                                             </div>
-                                            <div class="text-sm text-gray-500 dark:text-gray-400">{{ Str::limit($payment->description, 40) }}</div>
+                                            <div class="text-sm text-gray-500 dark:text-gray-400">{{ Str::limit($payment->concept, 40) }}</div>
                                         @endif
                                     </td>
 
                                     <!-- Fecha -->
                                     <td class="px-3 py-2">
-                                        @php
-                                            $displayDate = $payment->entry_type === 'payment' ? $payment->payment_date : $payment->created_at;
-                                        @endphp
-                                        <div class="text-sm text-gray-900 dark:text-white">{{ $displayDate->format('d/m/Y') }}</div>
-                                        <div class="text-sm text-gray-500 dark:text-gray-400">{{ $displayDate->format('H:i') }}</div>
+                                        <div class="text-sm text-gray-900 dark:text-white">{{ $payment->payment_date->format('d/m/Y') }}</div>
+                                        <div class="text-sm text-gray-500 dark:text-gray-400">{{ $payment->payment_date->format('H:i') }}</div>
                                     </td>
                                     
                                     {{-- Columna "Tipo" eliminada (info resumida en Paciente/De o en Método) --}}
 
                                     <!-- Método -->
                                     <td class="px-3 py-2">
-                                        @if($payment->entry_type === 'payment')
+                                        @if($payment->payment_type !== 'manual_income')
                                             @php
                                                 $methodLabels = [
                                                     'cash' => 'Efectivo',
@@ -275,7 +268,7 @@
 
                                     <!-- Monto -->
                                     <td class="px-3 py-2">
-                                        @if($payment->entry_type === 'payment')
+                                        @if($payment->payment_type !== 'manual_income')
                                             <div class="text-sm font-semibold {{ $payment->payment_type === 'refund' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400' }}">
                                                 {{ $payment->payment_type === 'refund' ? '-' : '' }}${{ number_format($payment->amount, 2) }}
                                             </div>
@@ -288,7 +281,7 @@
 
                                     <!-- Estado -->
                                     <td class="px-3 py-2">
-                                        @if($payment->entry_type === 'payment')
+                                        @if($payment->payment_type !== 'manual_income')
                                             @php
                                                 $statusColors = [
                                                     'pending' => 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
@@ -327,7 +320,7 @@
                                     <!-- Acciones -->
                                     <td class="px-3 py-2 text-right">
                                         <div class="flex items-center justify-end gap-2">
-                                            @if($payment->entry_type === 'payment')
+                                            @if($payment->payment_type !== 'manual_income')
                                                 <!-- Ver Pago de Paciente -->
                                                 <a href="{{ route('payments.show', $payment) }}"
                                                    class="p-1 text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"

--- a/resources/views/receipts/income-print.blade.php
+++ b/resources/views/receipts/income-print.blade.php
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Recibo de Ingreso N° {{ $receiptNumber }}</title>
+    <title>Recibo de Ingreso N° {{ $payment->receipt_number }}</title>
     <style>
         * {
             margin: 0;
@@ -295,32 +295,22 @@
             <div class="clinic-info">Tel: (3541) 705-281 | Email: puntosalud94@gmail.com</div>
 
             <div class="receipt-title">RECIBO DE INGRESO</div>
-            <div class="receipt-number">N° {{ $receiptNumber }}</div>
+            <div class="receipt-number">N° {{ $payment->receipt_number }}</div>
         </div>
 
         <!-- Información del Recibo -->
         <div class="info-section">
             <div class="info-row">
                 <span class="info-label">Fecha:</span>
-                <span class="info-value">{{ $cashMovement->created_at->format('d/m/Y H:i') }}</span>
-            </div>
-            <div class="info-row">
-                <span class="info-label">Recibido de:</span>
-                <span class="info-value">
-                    @if($cashMovement->reference_type === 'App\\Models\\Professional' && $cashMovement->reference)
-                        Dr. {{ $cashMovement->reference->full_name }}
-                    @else
-                        -
-                    @endif
-                </span>
+                <span class="info-value">{{ $payment->payment_date->format('d/m/Y H:i') }}</span>
             </div>
             <div class="info-row">
                 <span class="info-label">Categoría:</span>
-                <span class="info-value">{{ $cashMovement->movementType->name ?? 'Ingreso Manual' }}</span>
+                <span class="info-value">{{ $payment->income_category ? \App\Models\MovementType::where('code', $payment->income_category)->first()?->name : 'Ingreso Manual' }}</span>
             </div>
             <div class="info-row">
                 <span class="info-label">Registrado por:</span>
-                <span class="info-value">{{ $cashMovement->user->name ?? 'Sistema' }}</span>
+                <span class="info-value">{{ $payment->createdBy->name ?? 'Sistema' }}</span>
             </div>
         </div>
 
@@ -329,7 +319,7 @@
         <!-- Descripción/Concepto -->
         <div class="concept-section">
             <div class="concept-title">Concepto:</div>
-            <div class="concept-text">{{ $cashMovement->description }}</div>
+            <div class="concept-text">{{ $payment->concept }}</div>
         </div>
 
         <div class="divider"></div>
@@ -345,16 +335,8 @@
                         'debit_card' => '💳 Tarjeta de Débito',
                         'credit_card' => '💳 Tarjeta de Crédito',
                     ];
-                    // Extraer el método de pago de la descripción si está disponible
-                    $paymentMethod = '-';
-                    foreach($paymentMethods as $key => $label) {
-                        if(stripos($cashMovement->description, $key) !== false) {
-                            $paymentMethod = $label;
-                            break;
-                        }
-                    }
                 @endphp
-                {{ $paymentMethod }}
+                {{ $paymentMethods[$payment->payment_method] ?? '-' }}
             </span>
         </div>
 
@@ -362,7 +344,7 @@
         <div class="amount-section">
             <div class="amount-row">
                 <span class="amount-label">MONTO RECIBIDO:</span>
-                <span class="amount-value">${{ number_format($cashMovement->amount, 2, ',', '.') }}</span>
+                <span class="amount-value">${{ number_format($payment->amount, 2, ',', '.') }}</span>
             </div>
         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,7 +91,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/cash/withdrawal', [App\Http\Controllers\CashController::class, 'withdrawalForm'])->name('cash.withdrawal.store');
     Route::get('/cash/manual-income', [App\Http\Controllers\CashController::class, 'manualIncomeForm'])->name('cash.manual-income-form');
     Route::post('/cash/manual-income', [App\Http\Controllers\CashController::class, 'manualIncomeForm'])->name('cash.manual-income.store');
-    Route::get('/cash/income-receipt/{cashMovement}', [App\Http\Controllers\CashController::class, 'printIncomeReceipt'])->name('cash.income-receipt');
+    Route::get('/cash/income-receipt/{payment}', [App\Http\Controllers\CashController::class, 'printIncomeReceipt'])->name('cash.income-receipt');
     Route::get('/cash/movements/{cashMovement}', [App\Http\Controllers\CashController::class, 'getCashMovementDetails'])->name('cash.movement-details');
 
     // Cash opening/closing routes


### PR DESCRIPTION
Implementa sistema unificado de recibos donde TODOS los ingresos (pagos de pacientes + ingresos manuales) comparten numeración secuencial en la tabla payments.

Cambios principales:
- Migración: patient_id nullable + campo income_category en payments
- Ingresos manuales ahora crean Payment (con receipt_number) + CashMovement
- Vista receipts/income-print.blade.php con diseño verde distintivo
- Modal de confirmación para imprimir recibo después de registrar
- PaymentController simplificado: query directo sobre payments (sin combinar tablas)
- Vista payments/index unificada: muestra pagos e ingresos con fondo verde
- Numeración secuencial correcta: REC-00001, REC-00002, etc.

Impacto:
- Trazabilidad completa de todos los ingresos en un solo lugar
- Recibos imprimibles para cualquier tipo de ingreso
- Cumplimiento normativa fiscal (todos los ingresos con comprobante)
- Código más simple y mantenible

🤖 Generated with [Claude Code](https://claude.com/claude-code)