### PR TITLE
fix: Registrar método de pago en gastos y retiros mediante Payment/Pa…

### DIFF
--- a/app/Models/CashMovement.php
+++ b/app/Models/CashMovement.php
@@ -12,7 +12,6 @@ class CashMovement extends Model
     protected $fillable = [
         'movement_type_id',
         'amount',
-        'payment_method',
         'description',
         'reference_type',
         'reference_id',

--- a/resources/views/cash/withdrawal-form.blade.php
+++ b/resources/views/cash/withdrawal-form.blade.php
@@ -74,6 +74,23 @@
                         </select>
                     </div>
 
+                    <!-- Método de Pago -->
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                            Método de Pago *
+                        </label>
+                        <select x-model="form.payment_method"
+                                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500 dark:bg-gray-700 dark:text-white"
+                                required>
+                            <option value="">Seleccionar método</option>
+                            <option value="cash">Efectivo</option>
+                            <option value="transfer">Transferencia</option>
+                            <option value="debit_card">Tarjeta de Débito</option>
+                            <option value="credit_card">Tarjeta de Crédito</option>
+                            <option value="qr">QR / Mercado Pago</option>
+                        </select>
+                    </div>
+
                     <!-- Destinatario -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -133,7 +150,7 @@
                         Cancelar
                     </button>
                     <button type="submit"
-                            :disabled="loading || !form.amount || !form.withdrawal_type || !form.description"
+                            :disabled="loading || !form.amount || !form.payment_method || !form.withdrawal_type || !form.description"
                             class="flex-1 px-4 py-2 bg-red-600 hover:bg-red-700 disabled:bg-red-400 text-white rounded-lg transition-colors disabled:cursor-not-allowed">
                         <span x-show="!loading">Registrar Retiro</span>
                         <span x-show="loading">Procesando...</span>
@@ -152,6 +169,7 @@ function withdrawalForm() {
 
         form: {
             amount: '',
+            payment_method: '',
             withdrawal_type: '',
             description: '',
             recipient: '',
@@ -191,7 +209,7 @@ function withdrawalForm() {
             if (this.loading) return;
 
             // Validaciones básicas
-            if (!this.form.amount || !this.form.withdrawal_type || !this.form.description) {
+            if (!this.form.amount || !this.form.payment_method || !this.form.withdrawal_type || !this.form.description) {
                 this.showNotification('Complete todos los campos requeridos', 'error');
                 return;
             }


### PR DESCRIPTION
…ymentDetail

Soluciona error SQLSTATE[42S22] al intentar insertar payment_method en cash_movements.

Cambios en CashController:
- addExpense: Crear Payment y PaymentDetail para registrar método de pago
- withdrawalForm: Agregar validación y registro de payment_method
- Vincular CashMovement a Payment en lugar de directamente a Professional
- Actualizar responses para incluir payment_id y receipt_number

Cambios en CashMovement:
- Remover 'payment_method' del $fillable (columna no existe en tabla)
- El método de pago ahora se almacena en payment_details

Cambios en withdrawal-form.blade.php:
- Agregar campo "Método de Pago" al formulario
- Agregar payment_method al objeto form de Alpine.js
- Actualizar validaciones para requerir payment_method

Ahora todos los movimientos de caja (ingresos, gastos, retiros) registran el método de pago consistentemente en payment_details y generan receipt_number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)