### PR TITLE
fix: Correcciones críticas post-lanzamiento v2.6.0

### DIFF
--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -692,19 +692,44 @@ class AppointmentController extends Controller
             throw new \Exception('No se pueden registrar pagos. La caja debe estar abierta para realizar esta operación.');
         }
 
-        // Obtener balance actual con lock pesimista
-        $currentBalance = CashMovement::getCurrentBalanceWithLock();
-        $newBalance = $currentBalance + $payment->total_amount;
+        // NUEVO v2.6.0: Crear movimientos de caja SOLO para payment_details recibidos por el CENTRO
+        // Los pagos directos a profesionales (received_by='profesional') NO ingresan a caja del centro
+        $paymentDetails = $payment->paymentDetails()
+            ->where('received_by', 'centro')
+            ->get();
 
-        CashMovement::create([
-            'movement_type_id' => MovementType::getIdByCode('patient_payment'),
-            'amount' => $payment->total_amount,
-            'description' => $payment->concept ?: 'Pago anticipado - '.$payment->patient->full_name,
-            'reference_type' => Payment::class,
-            'reference_id' => $payment->id,
-            'balance_after' => $newBalance,
-            'user_id' => auth()->id(),
-        ]);
+        if ($paymentDetails->isEmpty()) {
+            // No hay movimientos para la caja del centro (todo fue directo a profesionales)
+            return;
+        }
+
+        $movementTypeId = MovementType::getIdByCode('patient_payment');
+        $baseDescription = $payment->concept ?: 'Pago anticipado - '.$payment->patient->full_name;
+
+        // Crear UN movimiento por cada payment_detail del centro
+        foreach ($paymentDetails as $paymentDetail) {
+            $currentBalance = CashMovement::getCurrentBalanceWithLock();
+            $newBalance = $currentBalance + $paymentDetail->amount;
+
+            $methodLabel = match($paymentDetail->payment_method) {
+                'cash' => 'Efectivo',
+                'transfer' => 'Transferencia',
+                'debit_card' => 'Débito',
+                'credit_card' => 'Crédito',
+                'qr' => 'QR',
+                default => ucfirst($paymentDetail->payment_method),
+            };
+
+            CashMovement::create([
+                'movement_type_id' => $movementTypeId,
+                'amount' => $paymentDetail->amount,
+                'description' => $baseDescription . ' - ' . $methodLabel,
+                'reference_type' => Payment::class,
+                'reference_id' => $payment->id,
+                'balance_after' => $newBalance,
+                'user_id' => auth()->id(),
+            ]);
+        }
     }
 
     /**
@@ -827,7 +852,14 @@ class AppointmentController extends Controller
             return 'centro';
         }
 
+        // QR siempre va al centro (cuenta bancaria del centro)
+        if ($paymentMethod === 'qr') {
+            return 'centro';
+        }
+
         // Transferencias: depende de la configuración del profesional
+        // - Si receives_transfers_directly = true → va directo al profesional
+        // - Si receives_transfers_directly = false → va al centro
         if ($paymentMethod === 'transfer') {
             return $professional->receives_transfers_directly ? 'profesional' : 'centro';
         }

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -215,7 +215,6 @@
                                 <td class="px-6 py-4">
                                     <div>
                                         <div class="text-sm font-semibold text-gray-900 dark:text-white" x-text="patient.first_name + ' ' + patient.last_name"></div>
-                                        {{-- <div class="text-sm text-gray-500 dark:text-gray-400" x-text="'ID: ' + patient.id"></div> --}}
                                     </div>
                                 </td>
                                 

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -230,8 +230,12 @@
                                     <!-- Paciente / De -->
                                     <td class="px-3 py-2">
                                         @if($payment->entry_type === 'payment')
-                                            <div class="text-sm font-medium text-gray-900 dark:text-white">{{ $payment->patient->full_name }}</div>
-                                            <div class="text-sm text-gray-500 dark:text-gray-400">DNI: {{ $payment->patient->dni }}</div>
+                                            @if($payment->patient)
+                                                <div class="text-sm font-medium text-gray-900 dark:text-white">{{ $payment->patient->full_name }}</div>
+                                                <div class="text-sm text-gray-500 dark:text-gray-400">DNI: {{ $payment->patient->dni }}</div>
+                                            @else
+                                                <div class="text-sm font-medium text-gray-500 dark:text-gray-400 italic">Sin paciente asociado</div>
+                                            @endif
                                         @else
                                             {{-- Ingreso Manual --}}
                                             <div class="text-sm font-medium text-gray-900 dark:text-white">

--- a/resources/views/payments/show.blade.php
+++ b/resources/views/payments/show.blade.php
@@ -20,14 +20,23 @@
         </div>
         
         <div class="flex gap-3">
-            <a href="{{ route('payments.index') }}" 
+            <a href="{{ route('payments.index') }}"
                class="inline-flex items-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white text-sm font-medium rounded-lg shadow-sm transition-colors duration-200">
                 <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
                 </svg>
                 Volver
             </a>
-            
+
+            <a href="{{ route('payments.print-receipt', $payment) }}"
+               target="_blank"
+               class="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg shadow-sm transition-colors duration-200">
+                <svg class="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5Zm-3 0h.008v.008H15V10.5Z" />
+                </svg>
+                Reimprimir Recibo
+            </a>
+
             {{-- Edición removida: usar retiros/ingresos manuales para correcciones --}}
         </div>
     </div>

--- a/resources/views/receipts/print.blade.php
+++ b/resources/views/receipts/print.blade.php
@@ -337,20 +337,48 @@
 
 
         <div class="divider"></div>
-        <div class="detail-row">
-            <span class="detail-label">Método de Pago:</span>
-            <span>
-                {{ match($payment->payment_method) {
-                    'cash' => '💵 Efectivo',
-                    'transfer' => '🏦 Transferencia',
-                    'card' => '💳 Tarjeta',
-                    'debit_card' => '💳 Tarjeta de Débito',
-                    'credit_card' => '💳 Tarjeta de Crédito',
-                    'qr' => '📱 QR',
-                    default => ucfirst($payment->payment_method)
-                } }}
-            </span>
-        </div>
+
+        <!-- Métodos de Pago (v2.6.0: soporta múltiples payment_details) -->
+        @if ($payment->paymentDetails->count() === 1)
+            {{-- Pago simple: un solo método --}}
+            <div class="detail-row">
+                <span class="detail-label">Método de Pago:</span>
+                <span>
+                    @php
+                        $method = $payment->paymentDetails->first()->payment_method;
+                    @endphp
+                    {{ match($method) {
+                        'cash' => '💵 Efectivo',
+                        'transfer' => '🏦 Transferencia',
+                        'debit_card' => '💳 Tarjeta de Débito',
+                        'credit_card' => '💳 Tarjeta de Crédito',
+                        'qr' => '📱 QR',
+                        default => ucfirst($method)
+                    } }}
+                </span>
+            </div>
+        @else
+            {{-- Pago mixto: múltiples métodos --}}
+            <div class="detail-row">
+                <span class="detail-label">Método de Pago:</span>
+                <span style="font-weight: 600; color: #2563eb;">Mixto</span>
+            </div>
+            @foreach ($payment->paymentDetails as $detail)
+                <div class="detail-row" style="padding-left: 20px; font-size: 12px;">
+                    <span>
+                        {{ match($detail->payment_method) {
+                            'cash' => '💵 Efectivo',
+                            'transfer' => '🏦 Transferencia',
+                            'debit_card' => '💳 Débito',
+                            'credit_card' => '💳 Crédito',
+                            'qr' => '📱 QR',
+                            default => ucfirst($detail->payment_method)
+                        } }}
+                    </span>
+                    <span style="font-weight: 600;">${{ number_format($detail->amount, 2, ',', '.') }}</span>
+                </div>
+            @endforeach
+        @endif
 
         <!-- Monto Total -->
         <div class="amount-section">


### PR DESCRIPTION
Liquidaciones Negativas:
- Permitir liquidar profesionales con saldo negativo (deben al centro)
- Quitar validación min:0 en LiquidationController
- NO crear movimiento de caja si monto negativo
- Mostrar botón Liquidar cuando hay turnos atendidos
- Archivos: LiquidationController.php, professional-liquidation*.blade.php

Movimientos de Caja (Corrección Crítica):
- DashboardController y AppointmentController ahora filtran por received_by='centro'
- Solo registrar en caja pagos que realmente ingresan al centro
- Pagos directos a profesionales NO generan movimiento de caja
- Caja del sistema ahora coincide con arqueo físico
- QR explícitamente marcado como ingreso al centro
- Archivos: DashboardController.php, AppointmentController.php

Recibos con Pagos Mixtos:
- Corregir vista de recibo para soportar múltiples payment_details
- Mostrar "Mixto" con desglose cuando hay varios métodos
- Archivo: receipts/print.blade.php

Otras Correcciones:
- Fix error "full_name on null" en payments/index
- Agregar botón "Reimprimir Recibo" en payments/show
- Archivos: payments/index.blade.php, payments/show.blade.php

Documentación:
- CHANGELOG.md actualizado con sección [2.6.0-fix]

🤖 Generated with [Claude Code](https://claude.com/claude-code)