### PR TITLE
fix: Eliminar receipt_number para gastos y permitir ñ en emails

### DIFF
--- a/app/Http/Controllers/PatientController.php
+++ b/app/Http/Controllers/PatientController.php
@@ -87,7 +87,7 @@ class PatientController extends Controller
                 'last_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'dni' => ['required', 'string', 'max:20', 'unique:patients', 'regex:/^[0-9.]+$/'],
                 'birth_date' => 'required|date|before:today',
-                'email' => 'nullable|email|max:255',
+                'email' => ['nullable', 'string', 'max:255', 'regex:/^[a-zA-Z0-9._%+\-ñÑ]+@[a-zA-Z0-9.\-ñÑ]+\.[a-zA-Z]{2,}$/'],
                 'phone' => 'required|string|max:255',
                 'address' => 'nullable|string|max:500',
                 'health_insurance' => 'nullable|string|max:255',
@@ -99,6 +99,7 @@ class PatientController extends Controller
                 'last_name.regex' => 'El apellido solo puede contener letras y espacios.',
                 'dni.regex' => 'El DNI solo puede contener números y puntos.',
                 'dni.unique' => 'El DNI ingresado ya está registrado en el sistema.',
+                'email.regex' => 'El email solo puede contener letras sin acentos, números, puntos, guiones y la letra ñ.',
             ]);
 
             // Formatear DNI con puntos
@@ -190,7 +191,7 @@ class PatientController extends Controller
                 'last_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'dni' => ['required', 'string', 'max:20', 'unique:patients,dni,'.$patient->id, 'regex:/^[0-9.]+$/'],
                 'birth_date' => 'required|date|before:today',
-                'email' => 'nullable|email|max:255',
+                'email' => ['nullable', 'string', 'max:255', 'regex:/^[a-zA-Z0-9._%+\-ñÑ]+@[a-zA-Z0-9.\-ñÑ]+\.[a-zA-Z]{2,}$/'],
                 'phone' => 'required|string|max:255',
                 'address' => 'nullable|string|max:500',
                 'health_insurance' => 'nullable|string|max:255',
@@ -202,6 +203,7 @@ class PatientController extends Controller
                 'last_name.regex' => 'El apellido solo puede contener letras y espacios.',
                 'dni.regex' => 'El DNI solo puede contener números y puntos.',
                 'dni.unique' => 'El DNI ingresado ya está registrado en el sistema.',
+                'email.regex' => 'El email solo puede contener letras sin acentos, números, puntos, guiones y la letra ñ.',
             ]);
 
             // Formatear DNI con puntos

--- a/app/Http/Controllers/ProfessionalController.php
+++ b/app/Http/Controllers/ProfessionalController.php
@@ -90,23 +90,28 @@ class ProfessionalController extends Controller
             $validated = $request->validate([
                 'first_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'last_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
-                'email' => 'nullable|string|email|max:255',
+                'email' => ['nullable', 'string', 'max:255', 'regex:/^[a-zA-Z0-9._%+\-ñÑ]+@[a-zA-Z0-9.\-ñÑ]+\.[a-zA-Z]{2,}$/'],
                 'phone' => 'nullable|string|max:255',
                 'dni' => ['required', 'string', 'max:20', 'unique:professionals', 'regex:/^[0-9.]+$/'],
                 'license_number' => 'nullable|string|max:255',
                 'specialty_id' => 'required|exists:specialties,id',
                 'commission_percentage' => 'required|numeric|min:0|max:100',
+                'receives_transfers_directly' => 'boolean',
                 'notes' => 'nullable|string|max:1000',
             ], [
                 'first_name.regex' => 'El nombre solo puede contener letras y espacios.',
                 'last_name.regex' => 'El apellido solo puede contener letras y espacios.',
                 'dni.regex' => 'El DNI solo puede contener números y puntos.',
                 'dni.unique' => 'El DNI ingresado ya está registrado en el sistema.',
+                'email.regex' => 'El email solo puede contener letras sin acentos, números, puntos, guiones y la letra ñ.',
             ]);
 
             // Formatear DNI con puntos
             $validated['dni'] = $this->formatDni($validated['dni']);
             $validated['is_active'] = true; // Por defecto activo
+
+            // Convertir receives_transfers_directly a booleano (por defecto false si no se envía)
+            $validated['receives_transfers_directly'] = $request->boolean('receives_transfers_directly');
 
             Professional::create($validated);
 
@@ -189,12 +194,13 @@ class ProfessionalController extends Controller
             $validated = $request->validate([
                 'first_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'last_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
-                'email' => 'nullable|string|email|max:255',
+                'email' => ['nullable', 'string', 'max:255', 'regex:/^[a-zA-Z0-9._%+\-ñÑ]+@[a-zA-Z0-9.\-ñÑ]+\.[a-zA-Z]{2,}$/'],
                 'phone' => 'nullable|string|max:255',
                 'dni' => ['required', 'string', 'max:20', 'unique:professionals,dni,'.$professional->id, 'regex:/^[0-9.]+$/'],
                 'license_number' => 'nullable|string|max:255',
                 'specialty_id' => 'required|exists:specialties,id',
                 'commission_percentage' => 'required|numeric|min:0|max:100',
+                'receives_transfers_directly' => 'boolean',
                 'notes' => 'nullable|string|max:1000',
                 'is_active' => 'required|in:0,1',
             ], [
@@ -202,6 +208,7 @@ class ProfessionalController extends Controller
                 'last_name.regex' => 'El apellido solo puede contener letras y espacios.',
                 'dni.regex' => 'El DNI solo puede contener números y puntos.',
                 'dni.unique' => 'El DNI ingresado ya está registrado en el sistema.',
+                'email.regex' => 'El email solo puede contener letras sin acentos, números, puntos, guiones y la letra ñ.',
             ]);
 
             // Formatear DNI con puntos
@@ -209,6 +216,9 @@ class ProfessionalController extends Controller
 
             // Convertir is_active a booleano
             $validated['is_active'] = $validated['is_active'] === '1';
+
+            // Convertir receives_transfers_directly a booleano
+            $validated['receives_transfers_directly'] = $request->boolean('receives_transfers_directly');
 
             $professional->update($validated);
 

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -266,6 +266,11 @@ class Payment extends Model
         parent::boot();
 
         static::creating(function ($payment) {
+            // No generar receipt_number para gastos (expenses)
+            if ($payment->payment_type === 'expense') {
+                return;
+            }
+
             if (empty($payment->receipt_number)) {
                 $payment->receipt_number = self::generateReceiptNumber();
             }

--- a/resources/views/receipts/print.blade.php
+++ b/resources/views/receipts/print.blade.php
@@ -387,6 +387,13 @@
                 <span class="amount-value">${{ number_format($payment->total_amount, 2, ',', '.') }}</span>
             </div>
         </div>
+
+        <!-- Disclaimer Legal -->
+        <div style="margin-top: 16px; padding-top: 12px; border-top: 1px solid #e5e7eb; text-align: center;">
+            <p style="font-size: 9px; color: #6b7280; line-height: 1.4; margin: 0;">
+                Comprobante interno - No válido como factura
+            </p>
+        </div>
     </div>
 
     <script>


### PR DESCRIPTION
- Payment: Los gastos (expenses) ya no generan número de recibo, solo se asientan en caja
- PatientController/ProfessionalController: Permitir letra ñ/Ñ en emails pero rechazar acentos (á,é,í,ó,ú)
- Validación de email con regex personalizado: /^[a-zA-Z0-9._%+\-ñÑ]+@[a-zA-Z0-9.\-ñÑ]+\.[a-zA-Z]{2,}$/
- receipts/print.blade.php: Mantiene disclaimer legal del commit anterior

🤖 Generated with [Claude Code](https://claude.com/claude-code)