### PR TITLE
hotfix: Corregir problema de zona horaria en vista Agenda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ---
 
+## [2.6.0-hotfix] - 2025-11-27
+
+### 🕐 Corregido - Problema Crítico de Zona Horaria en Vista Agenda
+
+**Descripción del Problema:**
+- El modal de turnos diarios mostraba fecha incorrecta (día anterior)
+- Botón "Nuevo Turno" deshabilitado incorrectamente para días actuales
+- Causado por conversión automática a UTC en funciones JavaScript de fecha
+- **Impacto**: Los usuarios NO podían crear turnos desde la vista Agenda
+
+**Causa Raíz:**
+- Uso de `new Date().toISOString().split('T')[0]` que convierte a UTC
+- Argentina (UTC-3): Antes de las 3 AM, la fecha resultante era del día anterior
+- Funciones `formatDateSpanish()` e `isDayInPast()` también afectadas
+
+**Solución Implementada:**
+
+1. **Nueva función helper `getTodayDate()`** (líneas 583-589):
+   ```javascript
+   getTodayDate() {
+       const now = new Date();
+       const year = now.getFullYear();
+       const month = String(now.getMonth() + 1).padStart(2, '0');
+       const day = String(now.getDate()).padStart(2, '0');
+       return `${year}-${month}-${day}`;
+   }
+   ```
+
+2. **Función `resetForm()` corregida** (línea 563):
+   - Antes: `appointment_date: new Date().toISOString().split('T')[0]`
+   - Ahora: `appointment_date: this.getTodayDate()`
+
+3. **Función `isDayInPast()` simplificada** (líneas 759-764):
+   - Comparación directa de strings de fecha para evitar timezone
+   - Usa `getTodayDate()` para obtener fecha actual correcta
+
+4. **Función `formatDateSpanish()` corregida** (líneas 721-730):
+   - Parse como fecha local: `new Date(year, month-1, day)`
+   - Evita interpretación UTC de strings de fecha
+
+**Archivos Modificados:**
+- `resources/views/agenda/index.blade.php` (líneas 563, 583-589, 721-730, 759-764)
+
+**Impacto:**
+- ✅ Modal de agenda muestra fecha correcta en el título
+- ✅ Botón "Nuevo Turno" se habilita/deshabilita correctamente
+- ✅ Usuarios pueden crear turnos sin confusión de fechas
+- ✅ Fix crítico que desbloqueó operación normal del sistema
+
+---
+
 ## [2.6.0-fix] - 2025-11-19
 
 ### 🐛 Correcciones y Mejoras Post-Lanzamiento v2.6.0

--- a/resources/views/agenda/index.blade.php
+++ b/resources/views/agenda/index.blade.php
@@ -560,7 +560,7 @@ document.addEventListener('alpine:init', () => {
             this.form = {
                 professional_id: '',
                 patient_id: '',
-                appointment_date: new Date().toISOString().split('T')[0],
+                appointment_date: this.getTodayDate(),
                 appointment_time: '',
                 duration: 30,
                 office_id: '',
@@ -578,6 +578,14 @@ document.addEventListener('alpine:init', () => {
                 package_sessions: '',
                 session_price: ''
             };
+        },
+
+        getTodayDate() {
+            const now = new Date();
+            const year = now.getFullYear();
+            const month = String(now.getMonth() + 1).padStart(2, '0');
+            const day = String(now.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
         },
 
         validateDateTime() {
@@ -711,7 +719,9 @@ document.addEventListener('alpine:init', () => {
         },
 
         formatDateSpanish(dateString) {
-            const date = new Date(dateString);
+            // Parse como fecha local para evitar problemas de timezone
+            const [year, month, day] = dateString.split('-');
+            const date = new Date(year, month - 1, day);
             return date.toLocaleDateString('es-ES', {
                 weekday: 'long',
                 day: 'numeric',
@@ -750,11 +760,9 @@ document.addEventListener('alpine:init', () => {
 
         isDayInPast() {
             if (!this.selectedDayDate) return false;
-            const selectedDate = new Date(this.selectedDayDate);
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
-            selectedDate.setHours(0, 0, 0, 0);
-            return selectedDate < today;
+            // Comparar solo las fechas como strings para evitar problemas de timezone
+            const today = this.getTodayDate();
+            return this.selectedDayDate < today;
         },
 
         isAppointmentInPast(appointment) {


### PR DESCRIPTION
Problema:
- Modal de turnos diarios mostraba fecha incorrecta (día anterior)
- Botón "Nuevo Turno" deshabilitado para días actuales
- Causado por conversión automática a UTC en JavaScript

Solución:
- Nueva función getTodayDate() para calcular fecha local correctamente
- Función resetForm() usa getTodayDate() en lugar de toISOString()
- Función isDayInPast() compara fechas como strings evitando timezone
- Función formatDateSpanish() parsea como fecha local

Archivos modificados:
- resources/views/agenda/index.blade.php (4 funciones corregidas)
- CHANGELOG.md (documentación del hotfix)

Impacto:
✓ Modal muestra fecha correcta
✓ Botón "Nuevo Turno" funciona correctamente
✓ Fix crítico que desbloqueó creación de turnos

🤖 Generated with [Claude Code](https://claude.com/claude-code)