### PR TITLE
feat: Habilitar Sábados en Agenda y horarios de profesionales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ---
 
+## [2.7.0] - 2026-02-09
+
+### 📅 Sábados en Agenda y Horarios de Profesionales
+
+**Descripción:**
+- Habilitación del día Sábado en la vista de Agenda para visualizar y gestionar turnos
+- Nuevo botón de acción rápida "Semana Completa" en la configuración de horarios de profesionales
+
+**Cambios Implementados:**
+
+1. **Agenda - Calendario con Sábados:**
+   - Grid del calendario ampliado de 5 a 6 columnas (Lun-Sáb)
+   - Los Sábados ahora se muestran en el calendario con la misma funcionalidad que los días de semana
+   - Si el profesional tiene horario configurado para Sábado, se pueden crear turnos normalmente
+   - Si no tiene horario, el día aparece en gris ("Día sin atención")
+
+2. **Horarios de Profesionales - Acción Rápida "Semana Completa":**
+   - Nuevo botón que configura Lun-Vie 9:00-17:00 + Sáb 8:00-15:00
+   - Horario de Sábado ajustado al horario del centro (8:00 a 15:00)
+   - Los botones existentes ("Horario de Oficina" y "Solo Mañanas") se mantienen sin cambios
+
+**Archivos Modificados:**
+- `resources/views/agenda/index.blade.php` (grid 6 columnas, inclusión de Sábado)
+- `resources/views/professionals/schedules/index.blade.php` (nuevo botón y función setFullWeekSchedule)
+
+**Impacto:**
+- ✅ Profesionales pueden atender los Sábados con gestión completa de turnos
+- ✅ Configuración rápida de horarios incluyendo Sábado
+- ✅ Sin impacto en profesionales que no atienden Sábados (día se muestra gris)
+
+---
+
 ## [2.6.3] - 2026-01-30
 
 ### 🗂️ Reorganización del Menú de Caja

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Laravel](https://img.shields.io/badge/Laravel-12.x-red?style=flat\&logo=laravel)](https://laravel.com)
 [![PHP](https://img.shields.io/badge/PHP-8.2-blue?style=flat\&logo=php)](https://php.net)
-[![Version](https://img.shields.io/badge/Version-2.6.1-green?style=flat)](#changelog)
+[![Version](https://img.shields.io/badge/Version-2.7.0-green?style=flat)](#changelog)
 [![License](https://img.shields.io/badge/License-MIT-yellow?style=flat)](#license)
 
 Sistema integral de gestión médica para clínicas y consultorios, desarrollado con Laravel 12 y tecnologías modernas.
@@ -148,6 +148,7 @@ php artisan config:clear
 
 ### 🔄 Últimas versiones
 
+* **v2.7.0** (2026-02-09) – 📅 Sábados en Agenda y Horarios: Habilitación del día Sábado en la vista de Agenda (grid de 6 columnas), nuevo botón de acción rápida "Semana Completa" (Lun-Sáb) en configuración de horarios con Sábado 8:00-15:00.
 * **v2.6.3** (2026-01-30) – 🗂️ Reorganización Menú de Caja + 📊 Exportación Excel/PDF: Nueva estructura de menú (Caja del Día, Movimientos de Caja, Análisis de Caja), exportación de reportes a Excel y PDF, impresión de movimientos, y correcciones en reportes por rango.
 * **v2.6.2-hotfix-4** (2026-01-21) – 🖨️ Impresión Individual de Liquidaciones: Icono de impresora en cada liquidación parcial para imprimir por separado, vista de impresión adaptada con resumen específico, y corrección de totales en pagos múltiples (efectivo + digital).
 * **v2.6.2-hotfix-3** (2026-01-21) – 🔄 Liquidaciones Parciales: Permite liquidar profesionales aunque tengan turnos pendientes, habilitando múltiples liquidaciones durante el día sin esperar al cierre.

--- a/resources/views/agenda/index.blade.php
+++ b/resources/views/agenda/index.blade.php
@@ -156,8 +156,8 @@
         <!-- Calendar Grid -->
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden">
             <!-- Calendar Header -->
-            <div class="grid grid-cols-5 bg-gray-50 dark:bg-gray-700">
-                @foreach(['Lun', 'Mar', 'Mié', 'Jue', 'Vie'] as $dayName)
+            <div class="grid grid-cols-6 bg-gray-50 dark:bg-gray-700">
+                @foreach(['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'] as $dayName)
                     <div class="p-4 text-center font-semibold text-gray-700 dark:text-gray-300 border-r border-gray-200 dark:border-gray-600 last:border-r-0">
                         {{ $dayName }}
                     </div>
@@ -165,7 +165,7 @@
             </div>
 
             <!-- Calendar Days -->
-            <div class="grid grid-cols-5">
+            <div class="grid grid-cols-6">
                 @php
                     $currentDay = $startOfCalendar->copy();
                 @endphp
@@ -174,8 +174,8 @@
                     @php
                         $dayOfWeek = $currentDay->dayOfWeek === 0 ? 7 : $currentDay->dayOfWeek; // Convert Sunday from 0 to 7
 
-                        // Skip Saturday (6) and Sunday (7)
-                        if ($dayOfWeek === 6 || $dayOfWeek === 7) {
+                        // Skip Sunday (7)
+                        if ($dayOfWeek === 7) {
                             $currentDay->addDay();
                             continue;
                         }

--- a/resources/views/professionals/schedules/index.blade.php
+++ b/resources/views/professionals/schedules/index.blade.php
@@ -52,11 +52,15 @@
                 <p class="text-xs text-blue-700 dark:text-blue-300 mt-1">Configuraciones predeterminadas para agilizar la configuración inicial.</p>
             </div>
             <div class="flex flex-wrap gap-2">
-                <button @click="setWeekdaySchedule()" 
+                <button @click="setWeekdaySchedule()"
                         class="px-3 py-1.5 text-xs font-medium text-blue-700 bg-white border border-blue-300 rounded hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-600 dark:hover:bg-gray-700 transition-colors">
                     <span class="hidden sm:inline">Horario de Oficina:</span> Lun-Vie 9:00-17:00
                 </button>
-                <button @click="setMorningSchedule()" 
+                <button @click="setFullWeekSchedule()"
+                        class="px-3 py-1.5 text-xs font-medium text-blue-700 bg-white border border-blue-300 rounded hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-600 dark:hover:bg-gray-700 transition-colors">
+                    <span class="hidden sm:inline">Semana Completa:</span> Lun-Sáb 9:00-17:00
+                </button>
+                <button @click="setMorningSchedule()"
                         class="px-3 py-1.5 text-xs font-medium text-blue-700 bg-white border border-blue-300 rounded hover:bg-blue-50 dark:bg-gray-800 dark:text-blue-300 dark:border-blue-600 dark:hover:bg-gray-700 transition-colors">
                     <span class="hidden sm:inline">Solo Mañanas:</span> Lun-Vie 9:00-13:00
                 </button>
@@ -180,6 +184,21 @@ function professionalSchedules() {
             }
             // Deshabilitar fines de semana
             this.schedules[6].enabled = false;
+            this.schedules[7].enabled = false;
+        },
+
+        setFullWeekSchedule() {
+            // Lunes a Viernes 9:00-17:00
+            for (let day = 1; day <= 5; day++) {
+                this.schedules[day].enabled = true;
+                this.schedules[day].start_time = '09:00';
+                this.schedules[day].end_time = '17:00';
+            }
+            // Sábado 8:00-15:00
+            this.schedules[6].enabled = true;
+            this.schedules[6].start_time = '08:00';
+            this.schedules[6].end_time = '15:00';
+            // Deshabilitar Domingo
             this.schedules[7].enabled = false;
         },
 


### PR DESCRIPTION
- Ampliar grid del calendario de 5 a 6 columnas (Lun-Sáb)
- Mostrar Sábados en la Agenda con soporte completo de turnos
- Agregar botón de acción rápida "Semana Completa" (Lun-Sáb) en horarios
- Horario de Sábado configurado como 8:00-15:00