### PR TITLE
fix: manejar error 419 (CSRF/sesión expirada) en formularios Alpine.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ---
 
+## [2.10.2] - 2026-03-26
+
+### 🔒 Fix CSRF 419 — Manejo de sesión expirada en formularios
+
+#### Problema
+En conexiones inestables (principalmente inalámbricas) la sesión en base de datos puede expirar o invalidarse mientras el usuario tiene un formulario abierto. Al intentar guardar, Laravel devuelve un **419 TokenMismatchException**, pero el frontend lo trataba como un error genérico: mostraba un toast inespecífico y la página quedaba bloqueada sin indicarle al usuario qué hacer.
+
+#### Corrección
+Se agregó manejo explícito del código HTTP 419 en los métodos de submit de todos los módulos con formularios Alpine.js. Cuando ocurre el error de sesión, ahora se muestra un toast de advertencia *"Tu sesión ha expirado. Redirigiendo..."* y a los 1,5 segundos se redirige automáticamente al login usando la URL devuelta por el servidor en `result.redirect`.
+
+**Archivos corregidos:**
+- `resources/views/patients/index.blade.php` — `submitForm()`
+- `resources/views/professionals/index.blade.php` — `submitForm()`
+- `resources/views/appointments/index.blade.php` — `submitForm()`
+- `resources/views/agenda/partials/scripts.blade.php` — `submitForm()` y `addPatient()`
+- `resources/views/payments/index.blade.php` — `annulPayment()`
+- `resources/views/cash/expense-form.blade.php` — submit de gastos
+- `resources/views/cash/manual-income-form.blade.php` — submit de ingresos manuales
+- `resources/views/cash/withdrawal-form.blade.php` — submit de retiros
+
+---
+
 ## [2.10.1] - 2026-03-26
 
 ### 🔐 Revisión de Seguridad y Cobertura de Tests

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Laravel](https://img.shields.io/badge/Laravel-12.x-red?style=flat\&logo=laravel)](https://laravel.com)
 [![PHP](https://img.shields.io/badge/PHP-8.2-blue?style=flat\&logo=php)](https://php.net)
-[![Version](https://img.shields.io/badge/Version-2.10.1-green?style=flat)](#changelog)
+[![Version](https://img.shields.io/badge/Version-2.10.2-green?style=flat)](#changelog)
 [![License](https://img.shields.io/badge/License-MIT-yellow?style=flat)](#license)
 
 Sistema integral de gestión médica para clínicas y consultorios, desarrollado con Laravel 12 y tecnologías modernas.
@@ -152,6 +152,7 @@ php artisan config:clear
 
 ### 🔄 Últimas versiones
 
+* **v2.10.2** (2026-03-26) – 🔒 Fix CSRF 419: manejo explícito de sesión expirada en todos los formularios Alpine.js; toast de advertencia + redirección automática al login en 8 módulos (pacientes, profesionales, turnos, agenda, pagos, caja).
 * **v2.10.1** (2026-03-26) – 🔐 Revisión de Seguridad: middleware de módulos en rutas core, fix bug crítico `payment_type='expense'`, eliminación de log de datos sensibles, fix IDOR en notas de profesionales. 138 tests unitarios con 13 factories nuevas cubriendo modelos y servicios clave.
 * **v2.10.0** (2026-03-26) – 📊 Módulo de Informes Analíticos: 13 nuevos reportes históricos (Profesionales, Pacientes, Financiero) con Chart.js, impresión universal y menú de Reportes reestructurado en submenús colapsables.
 * **v2.9.5** (2026-03-23) – 💰 Mejoras en vistas de Liquidación Profesional: totales de comisión explícitos, estilo minimalista en detalle de cobros, header de impresión rediseñado con logo.

--- a/resources/views/agenda/partials/scripts.blade.php
+++ b/resources/views/agenda/partials/scripts.blade.php
@@ -274,7 +274,10 @@ document.addEventListener('alpine:init', () => {
 
                 const result = await response.json();
 
-                if (response.ok && result.success) {
+                if (response.status === 419) {
+                    this.showNotification(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                    setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                } else if (response.ok && result.success) {
                     this.modalOpen = false;
                     this.showNotification(result.message, 'success');
                     // Reload page to show changes
@@ -956,7 +959,10 @@ function patientModal() {
                         location.reload();
                     }, 500);
                 } else {
-                    if (response.status === 422 && result.errors) {
+                    if (response.status === 419) {
+                        window.showToast(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                        setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                    } else if (response.status === 422 && result.errors) {
                         const errorMessages = Object.values(result.errors).flat().join('\n');
                         window.showToast('Errores de validación: ' + errorMessages, 'error');
                     } else {

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -699,7 +699,10 @@ function appointmentsPage() {
                 
                 const result = await response.json();
                 
-                if (response.ok && result.success) {
+                if (response.status === 419) {
+                    this.showNotification(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                    setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                } else if (response.ok && result.success) {
                     this.modalOpen = false;
                     this.refreshData();
                     this.showNotification(result.message, 'success');

--- a/resources/views/cash/expense-form.blade.php
+++ b/resources/views/cash/expense-form.blade.php
@@ -318,7 +318,10 @@ function expenseForm() {
 
                 const result = await response.json();
 
-                if (response.ok && result.success) {
+                if (response.status === 419) {
+                    window.showToast(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                    setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                } else if (response.ok && result.success) {
                     window.location.href = '/cash/daily';
                 } else {
                     window.showToast(result.message || 'Error al registrar el gasto', 'error');

--- a/resources/views/cash/manual-income-form.blade.php
+++ b/resources/views/cash/manual-income-form.blade.php
@@ -374,7 +374,10 @@ function incomeForm() {
 
                 const result = await response.json();
 
-                if (response.ok && result.success) {
+                if (response.status === 419) {
+                    window.showToast(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                    setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                } else if (response.ok && result.success) {
                     if (result.payment_id) {
                         const printReceipt = await SystemModal.confirm(
                             'Imprimir recibo',

--- a/resources/views/cash/withdrawal-form.blade.php
+++ b/resources/views/cash/withdrawal-form.blade.php
@@ -254,7 +254,10 @@ function withdrawalForm() {
 
                 const result = await response.json();
 
-                if (result.success) {
+                if (response.status === 419) {
+                    window.showToast(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                    setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                } else if (result.success) {
                     window.showToast(result.message, 'success');
                     setTimeout(() => { window.location.href = '/cash/daily'; }, 1000);
                 } else {

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -545,7 +545,10 @@ function patientsPage() {
                 
                 const result = await response.json();
                 
-                if (response.ok && result.success) {
+                if (response.status === 419) {
+                    this.showNotification(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                    setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                } else if (response.ok && result.success) {
                     this.modalOpen = false;
                     this.refreshData();
                     this.showNotification(result.message, 'success');

--- a/resources/views/payments/index.blade.php
+++ b/resources/views/payments/index.blade.php
@@ -513,7 +513,10 @@ async function annulPayment(paymentId, receiptNumber) {
 
         const result = await response.json();
 
-        if (result.success) {
+        if (response.status === 419) {
+            window.showToast(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+            setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+        } else if (result.success) {
             window.showToast(`Pago anulado exitosamente. Recibo: ${result.refund_receipt}`, 'success');
             window.location.reload();
         } else {

--- a/resources/views/professionals/index.blade.php
+++ b/resources/views/professionals/index.blade.php
@@ -548,7 +548,10 @@ function professionalsPage() {
                 
                 const result = await response.json();
                 
-                if (response.ok && result.success) {
+                if (response.status === 419) {
+                    this.showNotification(result.message || 'Tu sesión ha expirado. Redirigiendo...', 'warning');
+                    setTimeout(() => { window.location.href = result.redirect || '/login'; }, 1500);
+                } else if (response.ok && result.success) {
                     this.modalOpen = false;
                     this.refreshData();
                     this.showNotification(result.message, 'success');


### PR DESCRIPTION
En conexiones inestables la sesión puede invalidarse sin que el usuario lo sepa. El 419 que devuelve Laravel quedaba sin manejo específico y se mostraba como un error genérico. Ahora se intercepta el status 419 en todos los submitForm() / métodos de guardado: toast de advertencia + redirección automática al login en 1.5 s usando result.redirect.

Módulos corregidos: pacientes, profesionales, turnos, agenda (submitForm
+ addPatient), pagos (annulPayment), caja (gasto, ingreso manual, retiro).

Bump v2.10.2. Actualiza CHANGELOG y README.