### PR TITLE
fix: login — contraseña oculta, Recordarme funcional y persistente

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 ### ✨ Mejoras de UX
 
 - **Ícono de ojo en campos de contraseña**: toggle mostrar/ocultar en los campos de contraseña del login, gestión de usuarios y perfil de usuario. Ícono cambia según el estado (ojo abierto = oculto, ojo tachado = visible).
+- **Fix: contraseña visible en login**: Alpine.js no estaba cargado en la vista standalone del login (no extiende `layouts.app`), causando que el binding `:type` no funcionara y la contraseña se mostrara en texto plano. Se agrega Alpine.js CDN directamente en el `<head>` del login.
+- **Fix: "Recordarme" no funcionaba**: `Auth::attempt()` no recibía el flag `remember`. Corregido pasando `$request->boolean('remember')`.
 
 ---
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -34,7 +34,7 @@ class AuthController extends Controller
         ]);
 
         // Intentar autenticación con usuarios activos únicamente
-        if (Auth::attempt($credentials) && Auth::user()->isActive()) {
+        if (Auth::attempt($credentials, $request->boolean('remember')) && Auth::user()->isActive()) {
             // Verificar bloqueo del centro
             if (setting('center_active', '1') !== '1' && ! Auth::user()->canAccessModule('system')) {
                 Auth::logout();

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -15,6 +15,7 @@
     <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
 
 <body class="bg-gradient-to-br from-emerald-50 to-green-100 min-h-screen">
@@ -143,7 +144,7 @@
                         <!-- Remember me -->
                         <div class="flex items-center justify-between">
                             <label class="flex items-center">
-                                <input type="checkbox" name="remember"
+                                <input type="checkbox" name="remember" {{ old('remember') ? 'checked' : '' }}
                                     class="w-4 h-4 text-emerald-600 bg-gray-100 border-gray-300 rounded focus:ring-emerald-500 focus:ring-2">
                                 <span class="ml-2 text-sm text-gray-700">Recordarme</span>
                             </label>


### PR DESCRIPTION
- Alpine.js CDN agregado al login (vista standalone sin layouts.app) para que funcione el toggle ojo en el campo contraseña.
- Auth::attempt() recibe $request->boolean('remember') para activar la sesión persistente al marcar Recordarme.
- Checkbox Recordarme se mantiene marcado tras error de validación usando old('remember').