### PR TITLE
feat(v2.12.0): sub-permisos granulares por perfil

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Profile;
 use App\Models\ProfileModule;
+use App\Models\ProfilePermission;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
@@ -17,24 +18,29 @@ class ProfileController extends Controller
     {
         Gate::authorize('viewAny', Profile::class);
 
-        $profiles = Profile::with('modules')->withCount('users')->orderBy('name')->get();
+        $profiles = Profile::with(['modules', 'permissions'])->withCount('users')->orderBy('name')->get();
         $modules = Profile::MODULES;
+        $availablePermissions = Profile::PERMISSIONS;
 
-        return view('profiles.index', compact('profiles', 'modules'));
+        return view('profiles.index', compact('profiles', 'modules', 'availablePermissions'));
     }
 
     /**
-     * Crear nuevo perfil con módulos seleccionados
+     * Crear nuevo perfil con módulos y permisos seleccionados
      */
     public function store(Request $request)
     {
         Gate::authorize('create', Profile::class);
 
+        $allPermissions = collect(Profile::PERMISSIONS)->flatten()->keys()->toArray();
+
         $validator = Validator::make($request->all(), [
-            'name' => ['required', 'string', 'max:255', 'unique:profiles'],
-            'description' => ['nullable', 'string', 'max:500'],
-            'modules' => ['nullable', 'array'],
-            'modules.*' => ['string', 'in:' . implode(',', array_keys(Profile::MODULES))],
+            'name'          => ['required', 'string', 'max:255', 'unique:profiles'],
+            'description'   => ['nullable', 'string', 'max:500'],
+            'modules'       => ['nullable', 'array'],
+            'modules.*'     => ['string', 'in:' . implode(',', array_keys(Profile::MODULES))],
+            'permissions'   => ['nullable', 'array'],
+            'permissions.*' => ['string', 'in:' . implode(',', $allPermissions)],
         ]);
 
         if ($validator->fails()) {
@@ -42,12 +48,16 @@ class ProfileController extends Controller
         }
 
         $profile = Profile::create([
-            'name' => $request->name,
+            'name'        => $request->name,
             'description' => $request->description,
         ]);
 
         foreach ($request->input('modules', []) as $module) {
             ProfileModule::create(['profile_id' => $profile->id, 'module' => $module]);
+        }
+
+        foreach ($request->input('permissions', []) as $permission) {
+            ProfilePermission::create(['profile_id' => $profile->id, 'permission' => $permission]);
         }
 
         return response()->json([
@@ -57,17 +67,21 @@ class ProfileController extends Controller
     }
 
     /**
-     * Actualizar nombre y módulos de un perfil
+     * Actualizar nombre, módulos y permisos de un perfil
      */
     public function update(Request $request, Profile $profile)
     {
         Gate::authorize('update', $profile);
 
+        $allPermissions = collect(Profile::PERMISSIONS)->flatten()->keys()->toArray();
+
         $validator = Validator::make($request->all(), [
-            'name' => ['required', 'string', 'max:255', 'unique:profiles,name,' . $profile->id],
-            'description' => ['nullable', 'string', 'max:500'],
-            'modules' => ['nullable', 'array'],
-            'modules.*' => ['string', 'in:' . implode(',', array_keys(Profile::MODULES))],
+            'name'          => ['required', 'string', 'max:255', 'unique:profiles,name,' . $profile->id],
+            'description'   => ['nullable', 'string', 'max:500'],
+            'modules'       => ['nullable', 'array'],
+            'modules.*'     => ['string', 'in:' . implode(',', array_keys(Profile::MODULES))],
+            'permissions'   => ['nullable', 'array'],
+            'permissions.*' => ['string', 'in:' . implode(',', $allPermissions)],
         ]);
 
         if ($validator->fails()) {
@@ -75,7 +89,7 @@ class ProfileController extends Controller
         }
 
         $profile->update([
-            'name' => $request->name,
+            'name'        => $request->name,
             'description' => $request->description,
         ]);
 
@@ -83,6 +97,12 @@ class ProfileController extends Controller
         $profile->modules()->delete();
         foreach ($request->input('modules', []) as $module) {
             ProfileModule::create(['profile_id' => $profile->id, 'module' => $module]);
+        }
+
+        // Reemplazar permisos
+        $profile->permissions()->delete();
+        foreach ($request->input('permissions', []) as $permission) {
+            ProfilePermission::create(['profile_id' => $profile->id, 'permission' => $permission]);
         }
 
         return response()->json([

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -15,7 +15,7 @@ class UserController extends Controller
      */
     public function index()
     {
-        $users = User::with(['lastLogin', 'profile.modules'])->orderBy('name')->get();
+        $users = User::with(['lastLogin', 'profile.modules', 'profile.permissions'])->orderBy('name')->get();
         $profiles = Profile::orderBy('name')->get();
 
         return view('users.index', compact('users', 'profiles'));

--- a/app/Http/Middleware/EnsurePermissionAccess.php
+++ b/app/Http/Middleware/EnsurePermissionAccess.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsurePermissionAccess
+{
+    public function handle(Request $request, Closure $next, string $permission): Response
+    {
+        if (! $request->user()?->canDo($permission)) {
+            abort(403, 'No tiene acceso a esta funcionalidad.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -23,6 +23,21 @@ class Profile extends Model
         'system'        => 'Sistema',
     ];
 
+    /**
+     * Sub-permisos granulares disponibles, agrupados por módulo padre
+     */
+    public const PERMISSIONS = [
+        'reports' => [
+            'reports.financiero.cash'          => 'Movimientos de Caja',
+            'reports.financiero.expenses'      => 'Informe de Gastos',
+            'reports.financiero.liquidaciones' => 'Liquidaciones Históricas',
+            'reports.financiero.pagos'         => 'Métodos de Pago',
+            'reports.financiero.os'            => 'Ingresos Obra Social',
+            'reports.financiero.cobros'        => 'Cobros Pendientes',
+            'reports.financiero.flujo'         => 'Flujo Mensual',
+        ],
+    ];
+
     protected $fillable = [
         'name',
         'description',
@@ -36,6 +51,11 @@ class Profile extends Model
         return $this->hasMany(ProfileModule::class);
     }
 
+    public function permissions(): HasMany
+    {
+        return $this->hasMany(ProfilePermission::class);
+    }
+
     public function users(): HasMany
     {
         return $this->hasMany(User::class);
@@ -47,5 +67,13 @@ class Profile extends Model
     public function allowsModule(string $module): bool
     {
         return $this->modules->contains('module', $module);
+    }
+
+    /**
+     * Verificar si el perfil tiene un sub-permiso específico
+     */
+    public function allowsPermission(string $permission): bool
+    {
+        return $this->permissions->contains('permission', $permission);
     }
 }

--- a/app/Models/ProfilePermission.php
+++ b/app/Models/ProfilePermission.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProfilePermission extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = ['profile_id', 'permission'];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -88,6 +88,30 @@ class User extends Authenticatable
     }
 
     /**
+     * Verificar si el usuario puede realizar una acción (módulo completo o sub-permiso)
+     */
+    public function canDo(string $permission): bool
+    {
+        $module = explode('.', $permission)[0];
+
+        if ($this->canAccessModule($module)) {
+            return true;
+        }
+
+        if (! $this->profile) {
+            return false;
+        }
+
+        // Si se consulta solo el módulo padre, es true si tiene CUALQUIER sub-permiso de ese módulo
+        if ($permission === $module) {
+            return $this->profile->permissions
+                ->contains(fn ($p) => str_starts_with($p->permission, $module . '.'));
+        }
+
+        return $this->profile->allowsPermission($permission);
+    }
+
+    /**
      * Alias semántico: administrador = acceso a configuración
      */
     public function isAdmin(): bool

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'check.user.active' => \App\Http\Middleware\CheckUserActive::class,
             'check.center.active' => \App\Http\Middleware\CheckCenterActive::class,
             'module' => \App\Http\Middleware\EnsureModuleAccess::class,
+            'permission' => \App\Http\Middleware\EnsurePermissionAccess::class,
         ]);
 
         $middleware->web([

--- a/database/migrations/2026_04_22_080647_create_profile_permissions_table.php
+++ b/database/migrations/2026_04_22_080647_create_profile_permissions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('profile_permissions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('profile_id')->constrained()->cascadeOnDelete();
+            $table->string('permission');
+            $table->unique(['profile_id', 'permission']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('profile_permissions');
+    }
+};

--- a/database/seeders/ProfileSeeder.php
+++ b/database/seeders/ProfileSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Profile;
 use App\Models\ProfileModule;
+use App\Models\ProfilePermission;
 use Illuminate\Database\Seeder;
 
 class ProfileSeeder extends Seeder
@@ -41,5 +42,21 @@ class ProfileSeeder extends Seeder
         foreach ($generalModules as $module) {
             ProfileModule::create(['profile_id' => $general->id, 'module' => $module]);
         }
+
+        // Perfil Recepcionista Alto Nivel — acceso puntual a Movimientos de Caja
+        $recepcionista = Profile::firstOrCreate(
+            ['name' => 'Recepcionista Alto Nivel'],
+            ['description' => 'Acceso operativo + reporte de movimientos de caja']
+        );
+        $recepcionista->modules()->delete();
+        $recepcionistaMods = ['professionals', 'patients', 'appointments', 'agenda', 'cash', 'payments'];
+        foreach ($recepcionistaMods as $module) {
+            ProfileModule::create(['profile_id' => $recepcionista->id, 'module' => $module]);
+        }
+        $recepcionista->permissions()->delete();
+        ProfilePermission::create([
+            'profile_id' => $recepcionista->id,
+            'permission'  => 'reports.financiero.cash',
+        ]);
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -90,47 +90,62 @@
             'icon'  => '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0012 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75z" /></svg>',
         ];
 
-        // Agregar menú de reportes (solo si tiene módulo reports)
-        if (Auth::check() && Auth::user()->canAccessModule('reports')) {
+        // Agregar menú de reportes (módulo completo o sub-permiso)
+        if (Auth::check() && Auth::user()->canDo('reports')) {
+            $user = Auth::user();
+            $hasFullReports = $user->canAccessModule('reports');
+
+            $financieroChildren = [];
+            if ($user->canDo('reports.financiero.cash')) {
+                $financieroChildren[] = ['title' => 'Movimientos de Caja', 'href' => '/reports/cash'];
+            }
+            if ($hasFullReports) {
+                $financieroChildren[] = ['title' => 'Análisis de Caja',     'href' => '/cash/report'];
+                $financieroChildren[] = ['title' => 'Informe de Gastos',    'href' => '/reports/expenses'];
+                $financieroChildren[] = ['title' => 'Liquidaciones Hist.',  'href' => '/reports/liquidaciones-historicas'];
+                $financieroChildren[] = ['title' => 'Métodos de Pago',      'href' => '/reports/pagos/tendencia'];
+                $financieroChildren[] = ['title' => 'Ingresos Obra Social', 'href' => '/reports/ingresos-obra-social'];
+                $financieroChildren[] = ['title' => 'Cobros Pendientes',    'href' => '/reports/cobros-pendientes'];
+                $financieroChildren[] = ['title' => 'Flujo Mensual Caja',   'href' => '/reports/flujo-caja-mensual'];
+            }
+
+            $reportChildren = [];
+
+            if ($hasFullReports) {
+                $reportChildren[] = [
+                    'submenu' => true,
+                    'title' => 'Profesionales',
+                    'children' => [
+                        ['title' => 'Ingresos',    'href' => '/reports/profesionales/ingresos'],
+                        ['title' => 'Consultas',   'href' => '/reports/profesionales/consultas'],
+                        ['title' => 'Comisiones',  'href' => '/reports/profesionales/comisiones'],
+                        ['title' => 'Comparativa', 'href' => '/reports/profesionales/comparativa'],
+                    ],
+                ];
+                $reportChildren[] = [
+                    'submenu' => true,
+                    'title' => 'Pacientes',
+                    'children' => [
+                        ['title' => 'Ausentismo',       'href' => '/reports/pacientes/ausentismo'],
+                        ['title' => 'Retención',        'href' => '/reports/pacientes/retencion'],
+                        ['title' => 'Frecuencia',       'href' => '/reports/pacientes/frecuencia'],
+                        ['title' => 'Nuevos vs Viejos', 'href' => '/reports/pacientes/nuevos-viejos'],
+                    ],
+                ];
+            }
+
+            if (!empty($financieroChildren)) {
+                $reportChildren[] = [
+                    'submenu' => true,
+                    'title'    => 'Financiero',
+                    'children' => $financieroChildren,
+                ];
+            }
+
             $navigationItems[] = [
                 'title' => 'Reportes',
                 'icon' => '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" /></svg>',
-                'children' => [
-                    [
-                        'submenu' => true,
-                        'title' => 'Profesionales',
-                        'children' => [
-                            ['title' => 'Ingresos',    'href' => '/reports/profesionales/ingresos'],
-                            ['title' => 'Consultas',   'href' => '/reports/profesionales/consultas'],
-                            ['title' => 'Comisiones',  'href' => '/reports/profesionales/comisiones'],
-                            ['title' => 'Comparativa', 'href' => '/reports/profesionales/comparativa'],
-                        ],
-                    ],
-                    [
-                        'submenu' => true,
-                        'title' => 'Pacientes',
-                        'children' => [
-                            ['title' => 'Ausentismo',      'href' => '/reports/pacientes/ausentismo'],
-                            ['title' => 'Retención',       'href' => '/reports/pacientes/retencion'],
-                            ['title' => 'Frecuencia',      'href' => '/reports/pacientes/frecuencia'],
-                            ['title' => 'Nuevos vs Viejos','href' => '/reports/pacientes/nuevos-viejos'],
-                        ],
-                    ],
-                    [
-                        'submenu' => true,
-                        'title' => 'Financiero',
-                        'children' => [
-                            ['title' => 'Movimientos de Caja',  'href' => '/reports/cash'],
-                            ['title' => 'Análisis de Caja',     'href' => '/cash/report'],
-                            ['title' => 'Informe de Gastos',    'href' => '/reports/expenses'],
-                            ['title' => 'Liquidaciones Hist.',  'href' => '/reports/liquidaciones-historicas'],
-                            ['title' => 'Métodos de Pago',      'href' => '/reports/pagos/tendencia'],
-                            ['title' => 'Ingresos Obra Social', 'href' => '/reports/ingresos-obra-social'],
-                            ['title' => 'Cobros Pendientes',    'href' => '/reports/cobros-pendientes'],
-                            ['title' => 'Flujo Mensual Caja',   'href' => '/reports/flujo-caja-mensual'],
-                        ],
-                    ],
-                ]
+                'children' => $reportChildren,
             ];
         }
 

--- a/resources/views/profiles/index.blade.php
+++ b/resources/views/profiles/index.blade.php
@@ -74,6 +74,15 @@
                                     </span>
                                     @endif
                                 @endforeach
+                                @foreach($availablePermissions as $moduleKey => $perms)
+                                    @foreach($perms as $permKey => $permLabel)
+                                        @if($profile->permissions->contains('permission', $permKey))
+                                        <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+                                            {{ $permLabel }}
+                                        </span>
+                                        @endif
+                                    @endforeach
+                                @endforeach
                             </div>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
@@ -81,7 +90,7 @@
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                             @can('update', $profile)
-                            <button @click="openModal('edit', {{ $profile->id }}, '{{ addslashes($profile->name) }}', '{{ addslashes($profile->description ?? '') }}', {{ $profile->modules->pluck('module')->toJson() }})"
+                            <button @click="openModal('edit', {{ $profile->id }}, '{{ addslashes($profile->name) }}', '{{ addslashes($profile->description ?? '') }}', {{ $profile->modules->pluck('module')->toJson() }}, {{ $profile->permissions->pluck('permission')->toJson() }})"
                                     class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300">
                                 Editar
                             </button>
@@ -120,7 +129,7 @@
              x-transition:enter="transition ease-out duration-200"
              x-transition:enter-start="opacity-0 scale-95"
              x-transition:enter-end="opacity-100 scale-100"
-             class="bg-white dark:bg-gray-800 rounded-xl max-w-lg w-full shadow-xl">
+             class="bg-white dark:bg-gray-800 rounded-xl max-w-lg w-full shadow-xl max-h-[90vh] overflow-y-auto">
             <div class="p-6">
                 <div class="flex justify-between items-center mb-6">
                     <h3 class="text-lg font-semibold text-gray-900 dark:text-white"
@@ -172,6 +181,27 @@
                                 @endforeach
                             </div>
                         </div>
+
+                        <!-- Permisos específicos -->
+                        @foreach($availablePermissions as $moduleKey => $perms)
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Permisos individuales — {{ \App\Models\Profile::MODULES[$moduleKey] ?? ucfirst($moduleKey) }}
+                            </label>
+                            <p class="text-xs text-gray-400 dark:text-gray-500 mb-2">Otorgan acceso a funciones puntuales sin requerir el módulo completo.</p>
+                            <div class="grid grid-cols-1 gap-2">
+                                @foreach($perms as $permKey => $permLabel)
+                                <label class="flex items-center gap-2 p-2.5 rounded-lg border border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer transition-colors"
+                                       :class="form.permissions.includes('{{ $permKey }}') ? 'border-blue-300 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-700' : ''">
+                                    <input type="checkbox" value="{{ $permKey }}"
+                                           x-model="form.permissions"
+                                           class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                    <span class="text-sm text-gray-700 dark:text-gray-300">{{ $permLabel }}</span>
+                                </label>
+                                @endforeach
+                            </div>
+                        </div>
+                        @endforeach
                     </div>
 
                     <div class="flex gap-3 mt-6">
@@ -202,6 +232,7 @@ function profilesApp() {
             name: '',
             description: '',
             modules: [],
+            permissions: [],
         },
         formErrors: {},
 
@@ -215,7 +246,7 @@ function profilesApp() {
             this.formErrors = {};
         },
 
-        openModal(action, id = null, name = '', description = '', modules = []) {
+        openModal(action, id = null, name = '', description = '', modules = [], permissions = []) {
             this.clearErrors();
             this.isEditing = action === 'edit';
             this.currentId = id;
@@ -223,6 +254,7 @@ function profilesApp() {
                 name: name,
                 description: description,
                 modules: Array.isArray(modules) ? modules : [],
+                permissions: Array.isArray(permissions) ? permissions : [],
             };
             this.showModal = true;
         },
@@ -246,6 +278,7 @@ function profilesApp() {
             body.append('name', this.form.name);
             body.append('description', this.form.description);
             this.form.modules.forEach(m => body.append('modules[]', m));
+            this.form.permissions.forEach(p => body.append('permissions[]', p));
 
             try {
                 const response = await fetch(url, {

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,14 +101,20 @@ Route::middleware(['auth'])->group(function () {
     });
 
     // Reports routes
-    Route::get('/reports/daily-schedule', [ReportController::class, 'dailySchedule'])->name('reports.daily-schedule');
-    Route::get('/reports/daily-summary', [ReportController::class, 'dailySummary'])->name('reports.daily-summary');
-    Route::get('/reports/professional-liquidation', [ReportController::class, 'professionalLiquidation'])->name('reports.professional-liquidation');
-    Route::get('/reports/cash', [ReportController::class, 'cashReport'])->name('reports.cash');
-    Route::get('/reports/cash/print', [ReportController::class, 'cashMovementsPrint'])->name('reports.cash.print');
-    Route::get('/reports/expenses', [ReportController::class, 'expensesReport'])->name('reports.expenses');
-    Route::get('/reports/expenses/export', [ReportController::class, 'exportExpensesReportCsv'])->name('reports.expenses.export');
-    Route::get('/reports/expenses/print', [ReportController::class, 'printExpensesReport'])->name('reports.expenses.print');
+    Route::middleware(['module:reports'])->group(function () {
+        Route::get('/reports/daily-schedule', [ReportController::class, 'dailySchedule'])->name('reports.daily-schedule');
+        Route::get('/reports/daily-summary', [ReportController::class, 'dailySummary'])->name('reports.daily-summary');
+        Route::get('/reports/professional-liquidation', [ReportController::class, 'professionalLiquidation'])->name('reports.professional-liquidation');
+        Route::get('/reports/expenses', [ReportController::class, 'expensesReport'])->name('reports.expenses');
+        Route::get('/reports/expenses/export', [ReportController::class, 'exportExpensesReportCsv'])->name('reports.expenses.export');
+        Route::get('/reports/expenses/print', [ReportController::class, 'printExpensesReport'])->name('reports.expenses.print');
+    });
+
+    // Movimientos de caja: accesible con módulo completo O sub-permiso específico
+    Route::middleware(['permission:reports.financiero.cash'])->group(function () {
+        Route::get('/reports/cash', [ReportController::class, 'cashReport'])->name('reports.cash');
+        Route::get('/reports/cash/print', [ReportController::class, 'cashMovementsPrint'])->name('reports.cash.print');
+    });
 
     // Analytics Reports (v2.10.0) — bajo módulo 'reports'
     Route::middleware(['module:reports'])->group(function () {


### PR DESCRIPTION
Implementa sistema de permisos individuales que permite dar acceso a funcionalidades puntuales sin habilitar el módulo completo.

- Nueva tabla profile_permissions (profile_id, permission, unique)
- Modelo ProfilePermission + Profile::PERMISSIONS constant extensible
- User::canDo() verifica módulo completo O sub-permiso
- Middleware EnsurePermissionAccess (alias 'permission')
- Rutas /reports/cash y /reports/cash/print protegidas con permission:reports.financiero.cash
- Nav de Reportes condicionado por canDo() con ítems Financiero granulares
- UI de perfiles: sección 'Permisos individuales' en modal con checkboxes
- Seeder: perfil 'Recepcionista Alto Nivel' con módulos operativos + permiso reports.financiero.cash