### PR TITLE
fix(v2.12.0): corregir extracción de claves de permisos en validación

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -32,7 +32,7 @@ class ProfileController extends Controller
     {
         Gate::authorize('create', Profile::class);
 
-        $allPermissions = collect(Profile::PERMISSIONS)->flatten()->keys()->toArray();
+        $allPermissions = collect(Profile::PERMISSIONS)->flatMap(fn ($perms) => array_keys($perms))->toArray();
 
         $validator = Validator::make($request->all(), [
             'name'          => ['required', 'string', 'max:255', 'unique:profiles'],
@@ -73,7 +73,7 @@ class ProfileController extends Controller
     {
         Gate::authorize('update', $profile);
 
-        $allPermissions = collect(Profile::PERMISSIONS)->flatten()->keys()->toArray();
+        $allPermissions = collect(Profile::PERMISSIONS)->flatMap(fn ($perms) => array_keys($perms))->toArray();
 
         $validator = Validator::make($request->all(), [
             'name'          => ['required', 'string', 'max:255', 'unique:profiles,name,' . $profile->id],


### PR DESCRIPTION
flatMap(array_keys) en lugar de flatten()->keys() que devolvía índices numéricos.