### PR TITLE
feat: improve UX in patients, dashboard, appointments, agenda

### DIFF
--- a/app/Http/Controllers/AppointmentController.php
+++ b/app/Http/Controllers/AppointmentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ActivityLog;
 use App\Models\Appointment;
 use App\Models\CashMovement;
 use App\Models\Office;
@@ -21,6 +22,7 @@ use Illuminate\Support\Facades\DB;
 class AppointmentController extends Controller
 {
     protected $paymentAllocationService;
+
     protected $cashMovementService;
 
     public function __construct(PaymentAllocationService $paymentAllocationService, CashMovementService $cashMovementService)
@@ -34,7 +36,13 @@ class AppointmentController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Appointment::with(['professional.specialty', 'patient', 'office']);
+        $query = Appointment::with([
+            'professional.specialty',
+            'patient',
+            'office',
+            'createdBy:id,name',
+            'paymentAppointments.payment:id,receipt_number,total_amount,is_advance_payment',
+        ]);
 
         // Filtros de fecha (por defecto: hoy y próximos 7 días)
         $startDate = $request->get('start_date', today()->format('Y-m-d'));
@@ -230,6 +238,7 @@ class AppointmentController extends Controller
                 'estimated_amount' => $validated['estimated_amount'],
                 'status' => 'scheduled',
                 'is_between_turn' => $isBetweenTurn,
+                'created_by' => Auth::id(),
             ]);
 
             // Si se paga ahora, crear el pago (pero no asignarlo hasta que se atienda)
@@ -298,6 +307,47 @@ class AppointmentController extends Controller
         $appointment->load(['professional.specialty', 'patient', 'office']);
 
         return view('appointments.show', compact('appointment'));
+    }
+
+    /**
+     * Auditoría simple del turno (creación / última modificación / cancelación).
+     */
+    public function audit(Appointment $appointment)
+    {
+        $baseQuery = ActivityLog::with('user:id,name')
+            ->where('subject_type', 'Appointment')
+            ->where('subject_id', $appointment->id);
+
+        $created = (clone $baseQuery)
+            ->where('action', 'created')
+            ->orderBy('id', 'asc')
+            ->first();
+
+        $lastUpdated = (clone $baseQuery)
+            ->where('action', 'updated')
+            ->orderBy('id', 'desc')
+            ->first();
+
+        $cancelled = (clone $baseQuery)
+            ->where('action', 'updated')
+            ->where('subject_description', 'like', '%Cancelado%')
+            ->orderBy('id', 'desc')
+            ->first();
+
+        return response()->json([
+            'created' => $created ? [
+                'name' => $created->user?->name,
+                'at' => optional($created->created_at)->toIso8601String(),
+            ] : null,
+            'last_updated' => $lastUpdated ? [
+                'name' => $lastUpdated->user?->name,
+                'at' => optional($lastUpdated->created_at)->toIso8601String(),
+            ] : null,
+            'cancelled' => $cancelled ? [
+                'name' => $cancelled->user?->name,
+                'at' => optional($cancelled->created_at)->toIso8601String(),
+            ] : null,
+        ]);
     }
 
     /**
@@ -504,6 +554,7 @@ class AppointmentController extends Controller
                 'notes' => $validated['notes'],
                 'estimated_amount' => $validated['estimated_amount'],
                 'status' => 'scheduled',
+                'created_by' => Auth::id(),
             ]);
 
             DB::commit();
@@ -800,8 +851,8 @@ class AppointmentController extends Controller
     /**
      * Determina quién recibe el pago según el método de pago y la configuración del profesional
      *
-     * @param string $paymentMethod Método de pago (cash, transfer, debit_card, credit_card, other)
-     * @param \App\Models\Professional $professional Profesional del turno
+     * @param  string  $paymentMethod  Método de pago (cash, transfer, debit_card, credit_card, other)
+     * @param  \App\Models\Professional  $professional  Profesional del turno
      * @return string 'centro' o 'profesional'
      */
     private function determineReceivedBy(string $paymentMethod, $professional): string

--- a/app/Http/Controllers/PatientController.php
+++ b/app/Http/Controllers/PatientController.php
@@ -90,9 +90,9 @@ class PatientController extends Controller
                 'first_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'last_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'dni' => ['required', 'string', 'max:20', 'unique:patients', 'regex:/^[0-9.]+$/'],
-                'birth_date' => 'required|date|before:today',
+                'birth_date' => 'nullable|date|before:today',
                 'email' => ['nullable', 'string', 'max:255', 'regex:/^[a-zA-Z0-9._%+\-ñÑ]+@[a-zA-Z0-9.\-ñÑ]+\.[a-zA-Z]{2,}$/'],
-                'phone' => 'required|string|max:255',
+                'phone' => 'nullable|string|max:255',
                 'phone_landline' => 'nullable|string|max:50',
                 'address' => 'nullable|string|max:500',
                 'health_insurance' => 'nullable|string|max:255',
@@ -116,7 +116,7 @@ class PatientController extends Controller
                 return response()->json([
                     'success' => true,
                     'message' => 'Paciente creado exitosamente.',
-                    'patient' => $patient
+                    'patient' => $patient,
                 ]);
             }
 
@@ -195,9 +195,9 @@ class PatientController extends Controller
                 'first_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'last_name' => ['required', 'string', 'max:255', 'regex:/^[a-zA-ZáéíóúÁÉÍÓÚñÑ\s]+$/'],
                 'dni' => ['required', 'string', 'max:20', 'unique:patients,dni,'.$patient->id, 'regex:/^[0-9.]+$/'],
-                'birth_date' => 'required|date|before:today',
+                'birth_date' => 'nullable|date|before:today',
                 'email' => ['nullable', 'string', 'max:255', 'regex:/^[a-zA-Z0-9._%+\-ñÑ]+@[a-zA-Z0-9.\-ñÑ]+\.[a-zA-Z]{2,}$/'],
-                'phone' => 'required|string|max:255',
+                'phone' => 'nullable|string|max:255',
                 'phone_landline' => 'nullable|string|max:50',
                 'address' => 'nullable|string|max:500',
                 'health_insurance' => 'nullable|string|max:255',
@@ -343,10 +343,10 @@ class PatientController extends Controller
             ->orderBy('first_name')
             ->get()
             ->map(fn ($p) => [
-                'id'         => $p->id,
+                'id' => $p->id,
                 'first_name' => $p->first_name,
-                'last_name'  => $p->last_name,
-                'specialty'  => $p->specialty ? ['name' => $p->specialty->name] : null,
+                'last_name' => $p->last_name,
+                'specialty' => $p->specialty ? ['name' => $p->specialty->name] : null,
             ]);
 
         $optedOutIds = $patient->whatsappOptOuts()->pluck('professional_id')->toArray();
@@ -368,7 +368,7 @@ class PatientController extends Controller
             $isOptedOut = false;
         } else {
             WhatsAppOptOut::create([
-                'patient_id'      => $patient->id,
+                'patient_id' => $patient->id,
                 'professional_id' => $professional->id,
             ]);
             $isOptedOut = true;

--- a/resources/views/agenda/partials/notes-panel.blade.php
+++ b/resources/views/agenda/partials/notes-panel.blade.php
@@ -1,5 +1,5 @@
 {{-- Pestaña colapsada: visible cuando el panel está cerrado --}}
-<div x-show="!open"
+<div x-show="!open" x-cloak
      @click="toggleOpen()"
      class="fixed right-0 top-1/2 -translate-y-1/2 z-40 cursor-pointer select-none"
      title="Notas internas del profesional">
@@ -12,7 +12,7 @@
 </div>
 
 {{-- Panel expandido --}}
-<div x-show="open"
+<div x-show="open" x-cloak
      x-transition:enter="transition ease-out duration-200"
      x-transition:enter-start="translate-x-full opacity-0"
      x-transition:enter-end="translate-x-0 opacity-100"

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -251,13 +251,28 @@
                                     <span class="text-xs font-bold text-red-600">URGENCIA</span>
                                 </template>
                                 <template x-if="appointment.is_between_turn && appointment.duration > 0">
-                                    <span class="text-xs font-bold text-orange-600">ENTRETURNO</span>
+                                    <div class="flex items-center gap-1">
+                                        <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-orange-100 text-orange-800 border border-orange-300 dark:bg-orange-900/40 dark:text-orange-300 dark:border-orange-700"
+                                              title="Entreturno">
+                                            <span class="text-[10px] leading-none">⏱</span>
+                                        </span>
+                                        <span class="text-xs text-gray-500" x-text="appointment.duration + ' min'"></span>
+                                    </div>
                                 </template>
                                 <template x-if="!appointment.is_between_turn && appointment.duration > 0">
                                     <span class="text-xs text-gray-500" x-text="appointment.duration + ' min'"></span>
                                 </template>
                             </div>
                             <div class="flex gap-2">
+                                <button type="button"
+                                        @click="openInfoModal(appointment)"
+                                        class="p-2 text-gray-600 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-700 rounded-lg"
+                                        title="Información del turno">
+                                    <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                    </svg>
+                                </button>
                                 <button @click="openEditModal(appointment)" class="p-2 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg" title="Editar">
                                     <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                         <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
@@ -295,7 +310,7 @@
                             <th class="px-3 py-2 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">Estado</th>
                             <th class="px-3 py-2 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">Monto</th>
                             <th class="px-3 py-2 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">Consult.</th>
-                            <th class="px-3 py-2 text-right text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">Acciones</th>
+                            <th class="px-2 py-2 text-right text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">Acciones</th>
                         </tr>
                     </thead>
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-emerald-200/30 dark:divide-emerald-800/30">
@@ -351,9 +366,10 @@
                                         </span>
                                     </template>
                                     <template x-if="appointment.duration > 0 && appointment.is_between_turn">
-                                        <div class="flex items-center gap-1.5">
-                                            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-bold bg-orange-100 text-orange-800 border border-orange-300 dark:bg-orange-900/40 dark:text-orange-300 dark:border-orange-700">
-                                                ⏱️ ENTRETURNO
+                                        <div class="flex items-center gap-1">
+                                            <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-orange-100 text-orange-800 border border-orange-300 dark:bg-orange-900/40 dark:text-orange-300 dark:border-orange-700"
+                                                  title="Entreturno">
+                                                <span class="text-[10px] leading-none">⏱</span>
                                             </span>
                                             <span class="text-xs text-gray-500 dark:text-gray-400" x-text="appointment.duration + ' min'"></span>
                                         </div>
@@ -392,14 +408,25 @@
                                 </td>
 
                                 <!-- Acciones -->
-                                <td class="px-3 py-2 text-right">
-                                    <div class="flex items-center justify-end gap-1">
+                                <td class="px-2 py-2 text-right">
+                                    <div class="flex items-center justify-end gap-0.5">
                                         <!-- Botón Editar -->
                                         <button @click="openEditModal(appointment)"
-                                                class="p-1.5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors"
+                                                class="p-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors"
                                                 title="Editar turno">
                                             <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
+                                            </svg>
+                                        </button>
+
+                                        <!-- Botón Info -->
+                                        <button type="button"
+                                                @click="openInfoModal(appointment)"
+                                                class="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 rounded transition-colors"
+                                                title="Información del turno">
+                                            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                             </svg>
                                         </button>
 
@@ -407,7 +434,7 @@
                                         <div class="relative" x-data="{ statusDropdownOpen: false }" @click.away="statusDropdownOpen = false">
                                             <!-- Botón de estado -->
                                             <button @click="statusDropdownOpen = !statusDropdownOpen"
-                                                    class="p-1.5 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors"
+                                                    class="p-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors"
                                                     title="Cambiar estado">
                                                 <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                                     <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
@@ -502,6 +529,78 @@
     </div>
 
     @include('appointments.modal')
+
+    <!-- Modal: información del turno -->
+    <div x-show="infoModalOpen" x-cloak
+         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+         @click.self="infoModalOpen = false">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full p-6"
+             @keydown.escape.window="infoModalOpen = false">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+                Información del turno #<span x-text="infoModalData?.id"></span>
+            </h3>
+            <dl class="space-y-3 text-sm">
+                <div>
+                    <dt class="text-gray-500 dark:text-gray-400">Creado por</dt>
+                    <dd class="text-gray-900 dark:text-white"
+                        x-text="infoAudit?.created?.name ?? infoModalData?.created_by_name ?? 'No registrado'"></dd>
+                </div>
+                <div>
+                    <dt class="text-gray-500 dark:text-gray-400">Fecha de creación</dt>
+                    <dd class="text-gray-900 dark:text-white"
+                        x-text="formatDateTime(infoAudit?.created?.at ?? infoModalData?.created_at)"></dd>
+                </div>
+
+                <div x-show="infoAuditLoading">
+                    <dt class="text-gray-500 dark:text-gray-400">Auditoría</dt>
+                    <dd class="text-gray-400">Cargando...</dd>
+                </div>
+
+                <div x-show="infoAuditError">
+                    <dt class="text-gray-500 dark:text-gray-400">Auditoría</dt>
+                    <dd class="text-amber-600" x-text="infoAuditError"></dd>
+                </div>
+
+                <div x-show="infoAudit?.last_updated && infoAudit.last_updated.at !== (infoAudit?.created?.at ?? null) && infoAudit.last_updated.at !== (infoAudit?.cancelled?.at ?? null)">
+                    <dt class="text-gray-500 dark:text-gray-400">Última modificación</dt>
+                    <dd class="text-gray-900 dark:text-white">
+                        <span x-text="infoAudit?.last_updated?.name ?? '—'"></span>
+                        <span class="text-gray-400">•</span>
+                        <span x-text="formatDateTime(infoAudit?.last_updated?.at)"></span>
+                    </dd>
+                </div>
+
+                <div x-show="infoAudit?.cancelled">
+                    <dt class="text-gray-500 dark:text-gray-400">Cancelado por</dt>
+                    <dd class="text-gray-900 dark:text-white">
+                        <span x-text="infoAudit?.cancelled?.name ?? '—'"></span>
+                        <span class="text-gray-400">•</span>
+                        <span x-text="formatDateTime(infoAudit?.cancelled?.at)"></span>
+                    </dd>
+                </div>
+
+                <div>
+                    <dt class="text-gray-500 dark:text-gray-400">Recibo asociado</dt>
+                    <dd class="text-gray-900 dark:text-white">
+                        <template x-if="infoModalData?.receipt">
+                            <span>
+                                #<span x-text="infoModalData.receipt.number"></span>
+                                (<span x-text="formatMoney(infoModalData.receipt.amount)"></span>)
+                                <span x-show="infoModalData.receipt.is_advance" class="ml-1 text-xs text-amber-600">— Anticipo</span>
+                            </span>
+                        </template>
+                        <span x-show="!infoModalData?.receipt" class="text-gray-400">Sin recibo</span>
+                    </dd>
+                </div>
+            </dl>
+            <div class="mt-6 flex justify-end">
+                <button type="button" @click="infoModalOpen = false"
+                        class="px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-md text-sm">
+                    Cerrar
+                </button>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script>
@@ -520,6 +619,13 @@ function appointmentsPage() {
         loading: false,
         pastTimeError: '',
         formErrors: {},
+
+        // Modal info turno
+        infoModalOpen: false,
+        infoModalData: null,
+        infoAuditLoading: false,
+        infoAuditError: '',
+        infoAudit: null,
         
         init() {
             console.log('AppointmentsPage initialized');
@@ -618,6 +724,45 @@ function appointmentsPage() {
                 is_between_turn: appointment.is_between_turn || false
             };
             this.modalOpen = true;
+        },
+
+        openInfoModal(appointment) {
+            const firstPayment = appointment.payment_appointments?.[0]?.payment;
+
+            this.infoModalData = {
+                id: appointment.id,
+                created_by_name: appointment.created_by?.name,
+                created_at: appointment.created_at,
+                receipt: firstPayment ? {
+                    number: firstPayment.receipt_number,
+                    amount: firstPayment.total_amount,
+                    is_advance: firstPayment.is_advance_payment,
+                } : null,
+            };
+
+            this.infoAuditLoading = true;
+            this.infoAuditError = '';
+            this.infoAudit = null;
+            this.infoModalOpen = true;
+
+            fetch(`/appointments/${appointment.id}/audit`, {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+                .then(async (res) => {
+                    if (!res.ok) throw new Error('request_failed');
+                    return res.json();
+                })
+                .then((data) => {
+                    this.infoAudit = data;
+                })
+                .catch(() => {
+                    this.infoAuditError = 'No se pudo cargar la auditoría.';
+                })
+                .finally(() => {
+                    this.infoAuditLoading = false;
+                });
         },
         
         resetForm() {
@@ -862,6 +1007,32 @@ function appointmentsPage() {
                 hour: '2-digit',
                 minute: '2-digit',
                 hour12: false
+            });
+        },
+
+        formatDateTime(dateString) {
+            if (!dateString) return '—';
+            const date = new Date(dateString);
+            if (Number.isNaN(date.getTime())) return '—';
+
+            return date.toLocaleString('es-ES', {
+                day: '2-digit',
+                month: '2-digit',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false,
+            });
+        },
+
+        formatMoney(amount) {
+            if (amount === null || amount === undefined || amount === '') return '—';
+            const value = Number(amount);
+            if (Number.isNaN(value)) return '—';
+
+            return '$' + value.toLocaleString('es-AR', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
             });
         },
 

--- a/resources/views/dashboard/dashboard-appointments.blade.php
+++ b/resources/views/dashboard/dashboard-appointments.blade.php
@@ -69,17 +69,25 @@
                                 @endif
                             </div>
                             <div>
-                                <div class="flex items-center gap-1.5">
-                                    <p class="font-medium text-gray-900 dark:text-white">{{ $consulta['paciente'] }}</p>
-                                    @if(!empty($consulta['notes']))
-                                        <span title="{{ $consulta['notes'] }}" class="cursor-help flex-shrink-0 text-amber-500 dark:text-amber-400">
-                                            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                                                <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
-                                            </svg>
-                                        </span>
-                                    @endif
-                                </div>
+                                <p class="font-medium text-gray-900 dark:text-white">{{ $consulta['paciente'] }}</p>
                                 <p class="text-sm text-gray-600 dark:text-gray-400">{{ $consulta['profesional'] }} • {{ $consulta['hora'] }}</p>
+
+                                @if(!empty($consulta['notes']))
+                                    <div x-data="{ expanded: false }" class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic flex items-start gap-1">
+                                        <svg class="w-3 h-3 mt-0.5 flex-shrink-0 text-amber-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-1.5 3h6m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
+                                        </svg>
+                                        <span :class="expanded ? '' : 'line-clamp-1'" class="break-words">{{ $consulta['notes'] }}</span>
+                                        @if(strlen($consulta['notes']) > 60)
+                                            <button type="button"
+                                                    @click="expanded = !expanded"
+                                                    :aria-expanded="expanded"
+                                                    aria-label="Expandir nota"
+                                                    class="ml-1 text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 flex-shrink-0"
+                                                    x-text="expanded ? '-' : '+'"></button>
+                                        @endif
+                                    </div>
+                                @endif
                             </div>
                         </div>
                         <div class="text-right flex flex-col items-end gap-2">

--- a/resources/views/dashboard/dashboard.blade.php
+++ b/resources/views/dashboard/dashboard.blade.php
@@ -618,17 +618,25 @@ function urgencyModalDashboard() {
                                     @endif
                                 </div>
                                 <div>
-                                    <div class="flex items-center gap-1.5">
-                                        <p class="font-medium text-gray-900 dark:text-white">{{ $consulta['paciente'] }}</p>
-                                        @if(!empty($consulta['notes']))
-                                            <span title="{{ $consulta['notes'] }}" class="cursor-help flex-shrink-0 text-amber-500 dark:text-amber-400">
-                                                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
-                                                </svg>
-                                            </span>
-                                        @endif
-                                    </div>
+                                    <p class="font-medium text-gray-900 dark:text-white">{{ $consulta['paciente'] }}</p>
                                     <p class="text-sm text-gray-600 dark:text-gray-400">{{ $consulta['profesional'] }} • {{ $consulta['hora'] }}</p>
+
+                                    @if(!empty($consulta['notes']))
+                                        <div x-data="{ expanded: false }" class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 italic flex items-start gap-1">
+                                            <svg class="w-3 h-3 mt-0.5 flex-shrink-0 text-amber-500" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-1.5 3h6m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
+                                            </svg>
+                                            <span :class="expanded ? '' : 'line-clamp-1'" class="break-words">{{ $consulta['notes'] }}</span>
+                                            @if(strlen($consulta['notes']) > 60)
+                                                <button type="button"
+                                                        @click="expanded = !expanded"
+                                                        :aria-expanded="expanded"
+                                                        aria-label="Expandir nota"
+                                                        class="ml-1 text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 flex-shrink-0"
+                                                        x-text="expanded ? '-' : '+'"></button>
+                                            @endif
+                                        </div>
+                                    @endif
                                 </div>
                             </div>
                             <div class="text-right flex flex-col items-end gap-2">

--- a/resources/views/patients/detail.blade.php
+++ b/resources/views/patients/detail.blade.php
@@ -57,14 +57,14 @@
                         <div>
                             <label class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Fecha de Nacimiento</label>
                             <div class="text-lg text-gray-900 dark:text-white">
-                                {{ \Carbon\Carbon::parse($patient->birth_date)->format('d/m/Y') }}
+                                {{ $patient->birth_date ? \Carbon\Carbon::parse($patient->birth_date)->format('d/m/Y') : 'No especificado' }}
                             </div>
                         </div>
 
                         <div>
                             <label class="block text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Edad</label>
                             <div class="text-lg text-gray-900 dark:text-white">
-                                {{ \Carbon\Carbon::parse($patient->birth_date)->age }} años
+                                {{ $patient->birth_date ? \Carbon\Carbon::parse($patient->birth_date)->age . ' años' : '—' }}
                             </div>
                         </div>
 

--- a/resources/views/patients/index.blade.php
+++ b/resources/views/patients/index.blade.php
@@ -194,7 +194,7 @@
                         </div>
                         <div class="grid grid-cols-2 gap-2 text-xs text-gray-600 dark:text-gray-400">
                             <div><span class="font-medium">DNI:</span> <span x-text="patient.dni" class="font-mono"></span></div>
-                            <div><span class="font-medium">Edad:</span> <span x-text="calculateAge(patient.birth_date) + ' años'"></span></div>
+                            <div><span class="font-medium">Edad:</span> <span x-text="formatAge(patient.birth_date, ' años')"></span></div>
                             <div><span class="font-medium">Tel:</span> <span x-text="patient.phone"></span></div>
                             <div x-show="patient.phone_landline"><span class="font-medium">Fijo:</span> <span x-text="patient.phone_landline"></span></div>
                             <div>
@@ -288,7 +288,7 @@
 
                                 <!-- Edad -->
                                 <td class="px-4 py-2">
-                                    <span class="text-sm text-gray-900 dark:text-white" x-text="calculateAge(patient.birth_date) + ' a.'"></span>
+                                    <span class="text-sm text-gray-900 dark:text-white" x-text="formatAge(patient.birth_date, ' a.')"></span>
                                 </td>
 
                                 <!-- Obra Social -->
@@ -770,16 +770,26 @@ function patientsPage() {
         },
         
         calculateAge(birthDate) {
-            const today = new Date();
+            if (!birthDate) return null;
+
             const birth = new Date(birthDate);
+            if (Number.isNaN(birth.getTime())) return null;
+
+            const today = new Date();
             let age = today.getFullYear() - birth.getFullYear();
             const monthDiff = today.getMonth() - birth.getMonth();
-            
+
             if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
                 age--;
             }
-            
+
             return age;
+        },
+
+        formatAge(birthDate, suffix = '') {
+            const age = this.calculateAge(birthDate);
+            if (age === null) return '—';
+            return `${age}${suffix}`;
         },
 
         async toggleStatus(patient) {

--- a/resources/views/patients/modal.blade.php
+++ b/resources/views/patients/modal.blade.php
@@ -79,9 +79,9 @@
                             </div>
 
                             <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fecha de Nacimiento *</label>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fecha de Nacimiento</label>
                                 <div class="relative">
-                                    <input x-model="form.birth_date" type="date" required :max="getMaxDate()"
+                                    <input x-model="form.birth_date" type="date" :max="getMaxDate()"
                                            @input="clearError('birth_date')"
                                            :class="hasError('birth_date') ? 'border-red-500 focus:ring-red-500 focus:border-red-500' : 'border-gray-300 dark:border-gray-600 focus:ring-emerald-500 focus:border-emerald-500'"
                                            class="w-full px-3 py-2 border rounded-md shadow-sm dark:bg-gray-700 dark:text-white">
@@ -99,8 +99,8 @@
                         <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Información de Contacto</h3>
                         <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
                             <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Teléfono *</label>
-                                <input x-model="form.phone" type="tel" required placeholder="+54 11 1234-5678"
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Teléfono</label>
+                                <input x-model="form.phone" type="tel" placeholder="+54 11 1234-5678"
                                        @input="clearError('phone')"
                                        :class="hasError('phone') ? 'border-red-500 focus:ring-red-500 focus:border-red-500' : 'border-gray-300 dark:border-gray-600 focus:ring-emerald-500 focus:border-emerald-500'"
                                        class="w-full px-3 py-2 border rounded-md shadow-sm dark:bg-gray-700 dark:text-white">

--- a/routes/web.php
+++ b/routes/web.php
@@ -74,6 +74,7 @@ Route::middleware(['auth'])->group(function () {
     Route::middleware(['module:appointments'])->group(function () {
         Route::get('/appointments/available-slots', [AppointmentController::class, 'availableSlots'])->name('appointments.available-slots');
         Route::post('/appointments/urgency', [AppointmentController::class, 'storeUrgency'])->name('appointments.urgency.store');
+        Route::get('/appointments/{appointment}/audit', [AppointmentController::class, 'audit'])->name('appointments.audit');
         Route::resource('appointments', AppointmentController::class);
     });
 


### PR DESCRIPTION
Make patient birth date/phone optional, prevent agenda notes-panel FOUC, replace dashboard notes tooltip with inline clamp+expand, and add an appointments info modal that shows creator/updates/cancellations via ActivityLog plus created_by persistence.