### PR TITLE
fix(whatsapp): drop legacy unique index breaking reminder retries

### DIFF
--- a/app/Console/Commands/SendWhatsAppReminders.php
+++ b/app/Console/Commands/SendWhatsAppReminders.php
@@ -8,6 +8,7 @@ use App\Services\WhatsAppDispatchWindow;
 use App\Services\WhatsAppService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class SendWhatsAppReminders extends Command
 {
@@ -138,22 +139,30 @@ class SendWhatsAppReminders extends Command
         $retried = 0;
 
         foreach ($retryCandidates as $candidate) {
-            $hasSentOrPending = WhatsAppMessage::where('appointment_id', $candidate->appointment_id)
-                ->where('type', $candidate->type)
-                ->whereIn('status', ['sent', 'pending'])
-                ->exists();
-            if ($hasSentOrPending) {
-                continue;
-            }
+            try {
+                $hasSentOrPending = WhatsAppMessage::where('appointment_id', $candidate->appointment_id)
+                    ->where('type', $candidate->type)
+                    ->whereIn('status', ['sent', 'pending'])
+                    ->exists();
+                if ($hasSentOrPending) {
+                    continue;
+                }
 
-            $appointment = Appointment::with(['patient', 'professional.specialty'])
-                ->find($candidate->appointment_id);
-            if (! $appointment) {
-                continue;
-            }
+                $appointment = Appointment::with(['patient', 'professional.specialty'])
+                    ->find($candidate->appointment_id);
+                if (! $appointment) {
+                    continue;
+                }
 
-            if ($whatsAppService->queueAppointmentMessage($appointment, $candidate->type)) {
-                $retried++;
+                if ($whatsAppService->queueAppointmentMessage($appointment, $candidate->type)) {
+                    $retried++;
+                }
+            } catch (\Throwable $e) {
+                Log::error('WhatsApp retry candidate failed', [
+                    'appointment_id' => $candidate->appointment_id,
+                    'type' => $candidate->type,
+                    'error' => $e->getMessage(),
+                ]);
             }
         }
 

--- a/app/Console/Commands/WhatsAppRemindersStatus.php
+++ b/app/Console/Commands/WhatsAppRemindersStatus.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Appointment;
+use App\Services\WhatsAppDispatchWindow;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class WhatsAppRemindersStatus extends Command
+{
+    protected $signature = 'whatsapp:reminders-status
+                            {--limit=50 : Cuántos turnos mostrar (default 50)}
+                            {--all : Sin límite}
+                            {--json : Salida JSON en lugar de tabla}';
+
+    protected $description = 'Lista turnos pendientes de envío de recordatorio, con su dispatchTime calculado.';
+
+    public function handle(): int
+    {
+        $hoursBefore = (int) setting('whatsapp.hours_before', 24);
+        $window = WhatsAppDispatchWindow::fromSettings();
+
+        $horizon = now()
+            ->addHours($hoursBefore)
+            ->addMinutes(15)
+            ->addDays(WhatsAppDispatchWindow::ADVANCE_HORIZON_DAYS);
+
+        $query = Appointment::scheduled()
+            ->where('appointment_date', '>', now())
+            ->where('appointment_date', '<=', $horizon)
+            ->whereHas('patient', fn ($q) => $q->whereNotNull('phone')->where('phone', '!=', ''))
+            ->whereDoesntHave('whatsappMessages', fn ($q) => $q->where('type', 'reminder')->whereIn('status', ['sent', 'pending']))
+            ->withCount([
+                'whatsappMessages as reminder_failed_count' => fn ($q) => $q->where('type', 'reminder')->where('status', 'failed'),
+            ])
+            ->whereNotExists(function ($q) {
+                $q->select(DB::raw(1))
+                    ->from('whatsapp_opt_outs')
+                    ->whereColumn('whatsapp_opt_outs.patient_id', 'appointments.patient_id')
+                    ->whereColumn('whatsapp_opt_outs.professional_id', 'appointments.professional_id');
+            })
+            ->with(['patient:id,first_name,last_name,phone', 'professional:id,first_name,last_name'])
+            ->orderBy('appointment_date');
+
+        if (! $this->option('all')) {
+            $query->limit((int) $this->option('limit'));
+        }
+
+        $appointments = $query->get();
+
+        $now = now();
+
+        $rows = $appointments->map(function ($a) use ($hoursBefore, $window, $now) {
+            $ideal = $a->appointment_date->copy()->subHours($hoursBefore);
+            $dispatch = $window->computeDispatchTime($ideal);
+            $excluded = $a->reminder_failed_count >= 3;
+
+            $status = match (true) {
+                $excluded                  => 'EXCLUDED (3 fails)',
+                $now->greaterThanOrEqualTo($dispatch) => 'OVERDUE → próxima ventana',
+                default                    => 'queued → '.$dispatch->diffForHumans($now, ['parts' => 2, 'syntax' => \Carbon\CarbonInterface::DIFF_ABSOLUTE]),
+            };
+
+            return [
+                'id' => $a->id,
+                'appointment_date' => $a->appointment_date->toDateTimeString(),
+                'ideal_time' => $ideal->toDateTimeString(),
+                'dispatch_time' => $dispatch->toDateTimeString(),
+                'professional' => trim(($a->professional?->first_name ?? '').' '.($a->professional?->last_name ?? '')),
+                'patient' => trim(($a->patient?->first_name ?? '').' '.($a->patient?->last_name ?? '')),
+                'phone' => $a->patient?->phone,
+                'failed_reminders' => $a->reminder_failed_count,
+                'status' => $status,
+            ];
+        })->all();
+
+        if ($this->option('json')) {
+            $this->line(json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+            return self::SUCCESS;
+        }
+
+        $this->info(sprintf(
+            'Pendientes: %d (now=%s, hours_before=%d, window=%s-%s)',
+            count($rows),
+            $now->toDateTimeString(),
+            $hoursBefore,
+            (string) setting('whatsapp.window_start', '09:00'),
+            (string) setting('whatsapp.window_end', '21:00'),
+        ));
+
+        if (empty($rows)) {
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['id', 'appt_date', 'idealTime', 'dispatchTime', 'profesional', 'paciente', 'tel', 'fail', 'status'],
+            collect($rows)->map(fn ($r) => [
+                $r['id'],
+                $r['appointment_date'],
+                $r['ideal_time'],
+                $r['dispatch_time'],
+                substr($r['professional'], 0, 25),
+                substr($r['patient'], 0, 25),
+                $r['phone'],
+                $r['failed_reminders'],
+                $r['status'],
+            ])->all(),
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/database/migrations/2026_05_04_194043_drop_legacy_appointment_type_unique_from_whatsapp_messages.php
+++ b/database/migrations/2026_05_04_194043_drop_legacy_appointment_type_unique_from_whatsapp_messages.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // El índice legacy se llama literalmente `whatsapp_messages_appointment_type_unique`
+        // (sin `_id_`). La migración del 2026-04-28 intentó dropearlo con
+        // `dropUnique(['appointment_id','type'])`, pero Laravel auto-genera
+        // `whatsapp_messages_appointment_id_type_unique`, que no matchea — y por eso
+        // el unique sobrevivió y rompía los retries de creation/cancellation.
+        $exists = collect(DB::select('SHOW INDEX FROM whatsapp_messages'))
+            ->contains(fn ($i) => $i->Key_name === 'whatsapp_messages_appointment_type_unique');
+
+        if ($exists) {
+            Schema::table('whatsapp_messages', function (Blueprint $table) {
+                $table->dropIndex('whatsapp_messages_appointment_type_unique');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // No-op: el índice era legacy y bloqueaba los reintentos. No se restaura.
+    }
+};


### PR DESCRIPTION
El índice `whatsapp_messages_appointment_type_unique` sobre (appointment_id, type) quedó vivo: la migración del 2026-04-28 usó dropUnique con array, que auto-genera un nombre distinto al real. El retry de creation/cancellation chocaba con ese unique y devolvía 500 al cron de n8n.

- Migración idempotente que dropea el índice por nombre literal
- Try/catch en el bloque de retry (una fila problemática deja de matar la corrida)
- Nuevo comando `whatsapp:reminders-status` para auditar pendientes (--limit, --all, --json)