### PR TITLE
feat(whatsapp): dispatch reminders for next-day post-window appointments

### DIFF
--- a/app/Console/Commands/SendWhatsAppReminders.php
+++ b/app/Console/Commands/SendWhatsAppReminders.php
@@ -49,13 +49,16 @@ class SendWhatsAppReminders extends Command
             return self::SUCCESS;
         }
 
-        // Límite superior: considerar turnos cuyo idealTime (appointment_date - hours_before) cae
-        // dentro del horizonte máximo de adelanto (por días bloqueados / fuera de horario).
-        $windowEnd = now()->addHours($hoursBefore)->addMinutes(15)->addDays(WhatsAppDispatchWindow::ADVANCE_HORIZON_DAYS);
+        // -----------------------------------------------------------------------
+        // Pass 1: recordatorios basados en hours_before
+        // Considera turnos cuyo idealTime (appointment_date - hours_before) ya
+        // alcanzó su dispatchTime calculado.
+        // -----------------------------------------------------------------------
+        $queryHorizon = now()->addHours($hoursBefore)->addMinutes(15)->addDays(WhatsAppDispatchWindow::ADVANCE_HORIZON_DAYS);
 
         $appointments = Appointment::scheduled()
             ->where('appointment_date', '>', now())
-            ->where('appointment_date', '<=', $windowEnd)
+            ->where('appointment_date', '<=', $queryHorizon)
             ->whereHas('patient', fn ($q) => $q->whereNotNull('phone')->where('phone', '!=', ''))
             ->whereDoesntHave('whatsappMessages', fn ($q) => $q->where('type', 'reminder')->whereIn('status', ['sent', 'pending']))
             ->withCount([
@@ -83,49 +86,53 @@ class SendWhatsAppReminders extends Command
                 continue;
             }
 
-            $patient = $appointment->patient;
-            $formattedPhone = $whatsAppService->formatArgentinaPhone($patient->phone);
-
-            if (! $formattedPhone) {
-                $this->warn("Omitiendo turno #{$appointment->id}: teléfono inválido '{$patient->phone}'");
-                $skipped++;
-
-                continue;
-            }
-
-            $renderedMessage = $whatsAppService->renderTemplate($template, [
-                'nombre' => $patient->full_name,
-                'fecha' => $appointment->appointment_date->format('d/m/Y'),
-                'hora' => $appointment->appointment_date->format('H:i'),
-                'profesional' => $appointment->professional?->full_name ?? 'el/la profesional',
-                'especialidad' => $appointment->professional?->specialty?->name ?? '',
-            ]);
-
-            $waMessage = WhatsAppMessage::create([
-                'appointment_id' => $appointment->id,
-                'patient_id' => $patient->id,
-                'phone' => $formattedPhone,
-                'message' => $renderedMessage,
-                'status' => 'pending',
-                'instance' => $instance,
-                'type' => 'reminder',
-            ]);
-
-            $result = $whatsAppService->sendMessage($waMessage->phone, $waMessage->message);
-            if ($result['success']) {
-                $waMessage->markSent();
+            if ($this->sendReminderForAppointment($appointment, $whatsAppService, $instance, $template)) {
                 $dispatched++;
             } else {
-                $friendly = match ($result['error'] ?? '') {
-                    'not_configured' => 'WhatsApp no está configurado correctamente.',
-                    default => 'No se pudo enviar el mensaje. Intentá nuevamente.',
-                };
-                $waMessage->markFailed($friendly);
                 $skipped++;
             }
         }
 
+        // -----------------------------------------------------------------------
+        // Pass 2: anticipación de turnos del día siguiente fuera de ventana
+        // Turnos de mañana cuyo horario supera el cierre de la ventana de envío
+        // (ej: turno a las 18:00, 19:00 cuando la ventana cierra a las 17:30).
+        // Se despachan HOY durante la ventana activa para garantizar la entrega.
+        // -----------------------------------------------------------------------
+        $tomorrowStart = now()->addDay()->startOfDay();
+        $tomorrowEnd = now()->addDay()->endOfDay();
+
+        $nextDayPostWindow = Appointment::scheduled()
+            ->whereBetween('appointment_date', [$tomorrowStart, $tomorrowEnd])
+            ->whereRaw('TIME(appointment_date) >= ?', [$dispatchWindow->windowEnd()])
+            ->whereHas('patient', fn ($q) => $q->whereNotNull('phone')->where('phone', '!=', ''))
+            ->whereDoesntHave('whatsappMessages', fn ($q) => $q->where('type', 'reminder')->whereIn('status', ['sent', 'pending']))
+            ->withCount([
+                'whatsappMessages as reminder_failed_count' => fn ($q) => $q->where('type', 'reminder')->where('status', 'failed'),
+            ])
+            ->having('reminder_failed_count', '<', 3)
+            ->whereNotExists(function ($query) {
+                $query->select(DB::raw(1))
+                    ->from('whatsapp_opt_outs')
+                    ->whereColumn('whatsapp_opt_outs.patient_id', 'appointments.patient_id')
+                    ->whereColumn('whatsapp_opt_outs.professional_id', 'appointments.professional_id');
+            })
+            ->with(['patient', 'professional.specialty'])
+            ->get();
+
+        $advancedDispatched = 0;
+
+        foreach ($nextDayPostWindow as $appointment) {
+            if ($this->sendReminderForAppointment($appointment, $whatsAppService, $instance, $template)) {
+                $advancedDispatched++;
+            } else {
+                $skipped++;
+            }
+        }
+
+        // -----------------------------------------------------------------------
         // Pass de retry para creation/cancellation: failed con menos de 3 intentos
+        // -----------------------------------------------------------------------
         $retryCandidates = WhatsAppMessage::query()
             ->whereIn('type', ['creation', 'cancellation'])
             ->where('status', 'failed')
@@ -166,8 +173,62 @@ class SendWhatsAppReminders extends Command
             }
         }
 
-        $this->info("Reminders enviados: {$dispatched}, fallidos/omitidos: {$skipped}, retries (creation/cancellation): {$retried}");
+        $this->info(
+            "Reminders enviados: {$dispatched}"
+            .(($advancedDispatched > 0) ? " (+ {$advancedDispatched} anticipados del día siguiente)" : '')
+            .", fallidos/omitidos: {$skipped}, retries (creation/cancellation): {$retried}"
+        );
 
         return self::SUCCESS;
+    }
+
+    private function sendReminderForAppointment(
+        Appointment $appointment,
+        WhatsAppService $whatsAppService,
+        string $instance,
+        string $template,
+    ): bool {
+        $patient = $appointment->patient;
+        $formattedPhone = $whatsAppService->formatArgentinaPhone($patient->phone);
+
+        if (! $formattedPhone) {
+            $this->warn("Omitiendo turno #{$appointment->id}: teléfono inválido '{$patient->phone}'");
+
+            return false;
+        }
+
+        $renderedMessage = $whatsAppService->renderTemplate($template, [
+            'nombre' => $patient->full_name,
+            'fecha' => $appointment->appointment_date->format('d/m/Y'),
+            'hora' => $appointment->appointment_date->format('H:i'),
+            'profesional' => $appointment->professional?->full_name ?? 'el/la profesional',
+            'especialidad' => $appointment->professional?->specialty?->name ?? '',
+        ]);
+
+        $waMessage = WhatsAppMessage::create([
+            'appointment_id' => $appointment->id,
+            'patient_id' => $patient->id,
+            'phone' => $formattedPhone,
+            'message' => $renderedMessage,
+            'status' => 'pending',
+            'instance' => $instance,
+            'type' => 'reminder',
+        ]);
+
+        $result = $whatsAppService->sendMessage($waMessage->phone, $waMessage->message);
+
+        if ($result['success']) {
+            $waMessage->markSent();
+
+            return true;
+        }
+
+        $friendly = match ($result['error'] ?? '') {
+            'not_configured' => 'WhatsApp no está configurado correctamente.',
+            default => 'No se pudo enviar el mensaje. Intentá nuevamente.',
+        };
+        $waMessage->markFailed($friendly);
+
+        return false;
     }
 }

--- a/app/Services/WhatsAppDispatchWindow.php
+++ b/app/Services/WhatsAppDispatchWindow.php
@@ -14,6 +14,13 @@ class WhatsAppDispatchWindow
     public const ADVANCE_HORIZON_DAYS = 14;
 
     /**
+     * Margen respecto al cierre de ventana para garantizar que el scheduler
+     * (que corre cada 15 min) tenga al menos una corrida disponible antes
+     * de que la ventana se cierre.
+     */
+    public const SCHEDULER_SAFE_CUTOFF_MINUTES = 20;
+
+    /**
      * @param  array<int>  $sendDays  Carbon dayOfWeek: 0=domingo .. 6=sábado
      */
     public function __construct(
@@ -38,6 +45,11 @@ class WhatsAppDispatchWindow
             (string) setting('whatsapp.window_start', '09:00'),
             (string) setting('whatsapp.window_end', '21:00'),
         );
+    }
+
+    public function windowEnd(): string
+    {
+        return $this->windowEnd;
     }
 
     public function isAllowedAt(Carbon $moment): bool
@@ -73,21 +85,21 @@ class WhatsAppDispatchWindow
         // Día permitido pero fuera de horario
         if ($dayAllowed) {
             if ($idealTime->greaterThanOrEqualTo($end)) {
-                return $end->subMinute();
+                return $end->subMinutes(self::SCHEDULER_SAFE_CUTOFF_MINUTES);
             }
 
             if ($idealTime->lessThan($start)) {
                 $candidate = $idealTime->copy()->subDay();
 
-                return $this->previousAllowedDayEndMinusOneMinute($candidate);
+                return $this->previousAllowedDaySafeCutoff($candidate);
             }
         }
 
         // Día bloqueado: retroceder hasta el último día permitido
-        return $this->previousAllowedDayEndMinusOneMinute($idealTime);
+        return $this->previousAllowedDaySafeCutoff($idealTime);
     }
 
-    private function previousAllowedDayEndMinusOneMinute(Carbon $from): Carbon
+    private function previousAllowedDaySafeCutoff(Carbon $from): Carbon
     {
         $probe = $from->copy();
 
@@ -95,7 +107,7 @@ class WhatsAppDispatchWindow
             if (in_array($probe->dayOfWeek, $this->sendDays, true)) {
                 $end = $probe->copy()->setTimeFromTimeString($this->windowEnd);
 
-                return $end->subMinute();
+                return $end->subMinutes(self::SCHEDULER_SAFE_CUTOFF_MINUTES);
             }
 
             $probe->subDay();


### PR DESCRIPTION
- Add SCHEDULER_SAFE_CUTOFF_MINUTES = 20 constant to WhatsAppDispatchWindow
  so computed dispatch times fall at window_end - 20min instead of -1min,
  giving the 15-min scheduler at least one reliable run before the window closes.

- Rename previousAllowedDayEndMinusOneMinute → previousAllowedDaySafeCutoff
  and expose windowEnd() getter for use in the command.

- Add Pass 2 in SendWhatsAppReminders: explicitly queries tomorrow's
  appointments whose time >= window_end and dispatches them today during
  the active window, regardless of hours_before. This guarantees delivery
  for late-day appointments (18:00, 19:00, etc.) that would otherwise miss
  the window or be sent too close to the appointment time.

- Extract sendReminderForAppointment() private method to avoid code
  duplication between Pass 1 and Pass 2.

https://claude.ai/code/session_013t6ANPPvMMJcjEDc2iEfAT