### PR TITLE
fix: prevenir envío duplicado de comprobante por WhatsApp

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -528,6 +528,30 @@ class PaymentController extends Controller
 
         // Log en historial (asociamos al primer turno del pago, si existe)
         $appointmentId = $payment->paymentAppointments->first()?->appointment_id;
+
+        // Protección contra envíos duplicados: si ya se envió o está pendiente un recibo
+        // para este turno en los últimos 60 segundos, no reenviar.
+        if ($appointmentId) {
+            $recentDuplicate = WhatsAppMessage::where('appointment_id', $appointmentId)
+                ->where('type', 'receipt')
+                ->whereIn('status', ['sent', 'pending'])
+                ->where('created_at', '>=', now()->subSeconds(60))
+                ->exists();
+
+            if ($recentDuplicate) {
+                Log::warning('shareReceiptViaWhatsApp: envío duplicado bloqueado', [
+                    'payment_id'     => $payment->id,
+                    'appointment_id' => $appointmentId,
+                    'phone'          => $phone,
+                ]);
+
+                return response()->json([
+                    'success' => false,
+                    'message' => 'El recibo ya fue enviado recientemente. Esperá unos segundos antes de reenviar.',
+                ], 422);
+            }
+        }
+
         $waMessage = null;
         if ($appointmentId && $payment->patient_id) {
             $waMessage = WhatsAppMessage::create([
@@ -540,6 +564,13 @@ class PaymentController extends Controller
                 'type'           => 'receipt',
             ]);
         }
+
+        Log::info('shareReceiptViaWhatsApp: enviando recibo', [
+            'payment_id'     => $payment->id,
+            'appointment_id' => $appointmentId,
+            'professional'   => $professionals->pluck('full_name'),
+            'phone'          => $phone,
+        ]);
 
         $result = $whatsApp->sendMediaFile($phone, $base64, $filename, $caption);
 

--- a/resources/views/components/receipt-action-modal.blade.php
+++ b/resources/views/components/receipt-action-modal.blade.php
@@ -106,7 +106,18 @@
         show();
 
         return await new Promise((resolve) => {
+            let resolved = false;
             window.__closeReceiptActionModal = function (action) {
+                if (resolved) return;
+                resolved = true;
+                window.__closeReceiptActionModal = null;
+
+                // Deshabilitar el botón WhatsApp inmediatamente para evitar doble envío
+                if (action === 'whatsapp' && btnWhatsApp) {
+                    btnWhatsApp.disabled = true;
+                    btnWhatsApp.textContent = 'Enviando...';
+                }
+
                 hide();
                 resolve(action || 'cancel');
             };


### PR DESCRIPTION
Frontend: el botón "Compartir por WhatsApp" del modal se deshabilita
inmediatamente al hacer clic y la función __closeReceiptActionModal
se auto-anula tras el primer disparo, evitando resoluciones múltiples.

Backend: antes de enviar, se verifica si ya existe un WhatsAppMessage
de tipo 'receipt' con estado 'sent' o 'pending' para el mismo turno
en los últimos 60 segundos. Si hay duplicado, se bloquea el envío y
se registra un warning en el log para facilitar el diagnóstico.

https://claude.ai/code/session_0146r4ZspZ4PGDViHsvDb3kk