### PR TITLE
fix(whatsapp): no consultar la API externa cuando WhatsApp está deshabilitado

### DIFF
--- a/app/Http/Controllers/WhatsAppController.php
+++ b/app/Http/Controllers/WhatsAppController.php
@@ -27,7 +27,9 @@ class WhatsAppController extends Controller
      */
     public function index(): View
     {
-        $state        = $this->whatsApp->connectionState();
+        $state        = $this->whatsApp->isEnabled()
+            ? $this->whatsApp->connectionState()
+            : ['state' => 'disabled'];
         $isConnected  = ($state['state'] ?? '') === 'open';
         $isConfigured = $this->whatsApp->isConfigured();
         $features     = [
@@ -44,6 +46,10 @@ class WhatsAppController extends Controller
      */
     public function qrCode(Request $request): JsonResponse
     {
+        if (! $this->whatsApp->isEnabled()) {
+            return response()->json(['connected' => false, 'qr' => null, 'state' => 'disabled']);
+        }
+
         // Verificar estado primero — si ya está conectado no llamar a getQrCode()
         // (llamar a /instance/connect en una instancia activa puede interferir)
         $connState = $this->whatsApp->connectionState();
@@ -81,6 +87,15 @@ class WhatsAppController extends Controller
      */
     public function connectionStatus(): JsonResponse
     {
+        // Con WhatsApp deshabilitado no se consulta la API externa: cada poll
+        // del layout quedaba esperando el timeout HTTP y acaparaba workers PHP
+        if (! $this->whatsApp->isEnabled()) {
+            return response()->json([
+                'connected' => false,
+                'state'     => 'disabled',
+            ]);
+        }
+
         $state = $this->whatsApp->connectionState();
         return response()->json([
             'connected' => ($state['state'] ?? '') === 'open',

--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -111,6 +111,7 @@ class WhatsAppService
 
         try {
             $response = Http::withHeaders($this->headers())
+                ->connectTimeout(3)
                 ->timeout(10)
                 ->get("{$this->baseUrl()}/instance/connectionState/{$this->instance()}");
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -421,8 +421,10 @@
             }
 
             // WhatsApp: evitar llamada remota en servidor; actualizar por polling
+            // Solo si la función está habilitada — deshabilitada no hay nada que consultar
             const waDot = document.getElementById('wa-connection-dot');
-            if (waDot) {
+            const waEnabled = {{ setting('whatsapp.enabled', '0') === '1' ? 'true' : 'false' }};
+            if (waDot && waEnabled) {
                 const url = "{{ route('whatsapp.status') }}";
 
                 async function refreshWhatsAppStatus() {


### PR DESCRIPTION
El layout hace polling de /whatsapp/status cada 30s desde todas las
pestañas abiertas, y el endpoint llamaba a connectionState() con solo
verificar isConfigured(): con la función deshabilitada pero la URL/key
aún cargadas, cada poll hacía igual la llamada HTTP a Evolution API.
Con el servidor de Evolution inaccesible, cada poll retenía un worker
PHP hasta 10s de timeout; con varias pestañas abiertas los workers se
agotaban y el sitio entero dejaba de responder de forma intermitente.

- connectionStatus() y qrCode() cortan con state 'disabled' sin tocar
  la red cuando whatsapp.enabled = 0
- La página /whatsapp tampoco consulta connectionState() deshabilitada
- El layout ni siquiera inicia el polling si la función está apagada
- connectTimeout(3) en connectionState() para acotar el peor caso
  cuando está habilitada pero el servidor no responde

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ke37AqsXT63AnD8Rh1nbVQ