### PR TITLE
feat(agenda): mostrar módulos disponibles en la planilla impresa

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -9,11 +9,13 @@ use App\Models\Expense;
 use App\Models\MovementType;
 use App\Models\Professional;
 use App\Models\ProfessionalLiquidation;
+use App\Models\ScheduleException;
 use App\Services\WhatsAppService;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
@@ -278,33 +280,15 @@ class ReportController extends Controller
     {
         $professional = Professional::with('specialty')->findOrFail($professionalId);
 
-        $appointments = Appointment::with(['office', 'patient', 'paymentAppointments.payment'])
+        $appointmentModels = Appointment::with(['office', 'patient', 'paymentAppointments.payment'])
             ->where('professional_id', $professionalId)
             ->forDate($selectedDate)
             ->where('status', '!=', 'cancelled')
             ->orderBy('appointment_date')
-            ->get()
-            ->map(function ($appointment) {
-                return [
-                    'id' => $appointment->id,
-                    'time' => $appointment->appointment_date->format('H:i'),
-                    'patient_name' => $appointment->patient->full_name,
-                    'patient_phone' => $appointment->patient->phone,
-                    'patient_email' => $appointment->patient->email,
-                    'patient_dni' => $appointment->patient->dni,
-                    'patient_insurance' => $appointment->patient->insurance_company,
-                    'estimated_amount' => $appointment->estimated_amount ?? 0,
-                    'final_amount' => $appointment->final_amount,
-                    'status' => $appointment->status,
-                    'status_label' => AppointmentStatus::labelFor($appointment->status),
-                    'is_paid' => $appointment->paymentAppointments()->exists(),
-                    'payment_method' => $appointment->paymentAppointments->first()?->payment?->payment_method,
-                    'notes' => $appointment->notes,
-                    'office' => $appointment->office?->name ?? 'No asignado',
-                    'is_urgency' => $appointment->is_urgency,
-                    'is_between_turn' => $appointment->is_between_turn,
-                ];
-            })
+            ->get();
+
+        $appointments = $appointmentModels
+            ->map(fn ($appointment) => $this->mapAppointmentRow($appointment))
             ->sortByDesc('is_urgency')
             ->values();
 
@@ -323,10 +307,126 @@ class ReportController extends Controller
             'professional' => $professional,
             'date' => $selectedDate,
             'appointments' => $appointments,
+            'schedule_blocks' => $this->buildScheduleBlocks($professional, $selectedDate, $appointmentModels),
             'stats' => $stats,
             'generated_at' => now(),
             'generated_by' => Auth::user()?->name ?? 'Sistema',
         ];
+    }
+
+    private function mapAppointmentRow(Appointment $appointment): array
+    {
+        return [
+            'id' => $appointment->id,
+            'time' => $appointment->appointment_date->format('H:i'),
+            'patient_name' => $appointment->patient->full_name,
+            'patient_phone' => $appointment->patient->phone,
+            'patient_email' => $appointment->patient->email,
+            'patient_dni' => $appointment->patient->dni,
+            'patient_insurance' => $appointment->patient->insurance_company,
+            'estimated_amount' => $appointment->estimated_amount ?? 0,
+            'final_amount' => $appointment->final_amount,
+            'status' => $appointment->status,
+            'status_label' => AppointmentStatus::labelFor($appointment->status),
+            'is_paid' => $appointment->paymentAppointments()->exists(),
+            'payment_method' => $appointment->paymentAppointments->first()?->payment?->payment_method,
+            'notes' => $appointment->notes,
+            'office' => $appointment->office?->name ?? 'No asignado',
+            'is_urgency' => $appointment->is_urgency,
+            'is_between_turn' => $appointment->is_between_turn,
+        ];
+    }
+
+    /**
+     * Construye la grilla de módulos del día (turnos ocupados + espacios libres),
+     * respetando el módulo típico configurado para el profesional. Un turno más
+     * corto que el módulo típico "compensa" el sobrante: el módulo completo queda
+     * ocupado y no se ofrece el resto como libre.
+     */
+    private function buildScheduleBlocks(Professional $professional, Carbon $selectedDate, Collection $appointments): Collection
+    {
+        $isHoliday = ScheduleException::holidays()
+            ->active()
+            ->where('exception_date', $selectedDate->toDateString())
+            ->exists();
+
+        $duration = max((int) ($professional->appointmentSettings?->default_duration_minutes ?? 30), 10);
+
+        $schedules = $isHoliday
+            ? collect()
+            : $professional->getScheduleForDay($selectedDate->dayOfWeekIso)
+                ->sortBy(fn ($schedule) => $schedule->getRawOriginal('start_time'))
+                ->values();
+
+        $consumedIds = [];
+        $blocks = collect();
+
+        foreach ($schedules as $schedule) {
+            [$startH, $startM] = explode(':', Carbon::parse($schedule->getRawOriginal('start_time'))->format('H:i'));
+            [$endH, $endM] = explode(':', Carbon::parse($schedule->getRawOriginal('end_time'))->format('H:i'));
+            $blockStart = $selectedDate->copy()->setTime((int) $startH, (int) $startM);
+            $blockEnd = $selectedDate->copy()->setTime((int) $endH, (int) $endM);
+
+            $cursor = $blockStart->copy();
+
+            while ($cursor->lt($blockEnd)) {
+                $nextGrid = $cursor->copy()->addMinutes($duration)->min($blockEnd);
+
+                $appointment = $appointments->first(function ($candidate) use ($cursor, $nextGrid, $consumedIds) {
+                    if (in_array($candidate->id, $consumedIds, true)) {
+                        return false;
+                    }
+
+                    $appointmentStart = Carbon::parse($candidate->appointment_date);
+                    // Se usa un mínimo de 1 minuto para que un turno de urgencia (duration=0)
+                    // que cae justo en un límite de módulo igual sea detectado en ese módulo.
+                    $appointmentEnd = $appointmentStart->copy()->addMinutes(max($candidate->duration, 1));
+
+                    return $cursor->lt($appointmentEnd) && $nextGrid->gt($appointmentStart);
+                });
+
+                if ($appointment) {
+                    $blocks->push(array_merge($this->mapAppointmentRow($appointment), [
+                        'type' => 'occupied',
+                        'start' => Carbon::parse($appointment->appointment_date),
+                    ]));
+
+                    // Redondear hacia arriba al próximo límite de módulo: el módulo donde
+                    // empieza el turno queda ocupado completo (aunque el turno dure menos,
+                    // "se compensa el sobrante"), y si el turno se extiende más, se ocupan
+                    // también los módulos siguientes que abarque.
+                    $appointmentStart = Carbon::parse($appointment->appointment_date);
+                    $appointmentEnd = $appointmentStart->copy()->addMinutes($appointment->duration);
+                    $effectiveStart = $appointmentStart->max($blockStart);
+
+                    $moduleStartOffset = (int) (floor($blockStart->diffInMinutes($effectiveStart) / $duration) * $duration);
+                    $naiveEndOffset = $blockStart->diffInMinutes($appointmentEnd);
+                    $roundedEndOffset = max($moduleStartOffset + $duration, (int) (ceil($naiveEndOffset / $duration) * $duration));
+
+                    $cursor = $blockStart->copy()->addMinutes($roundedEndOffset);
+                    $consumedIds[] = $appointment->id;
+                } else {
+                    $blocks->push([
+                        'type' => 'available',
+                        'start' => $cursor->copy(),
+                        'end' => $nextGrid->copy(),
+                        'label' => 'Disponible',
+                    ]);
+                    $cursor = $nextGrid;
+                }
+            }
+        }
+
+        $appointments
+            ->reject(fn ($appointment) => in_array($appointment->id, $consumedIds, true))
+            ->each(function ($appointment) use ($blocks) {
+                $blocks->push(array_merge($this->mapAppointmentRow($appointment), [
+                    'type' => 'occupied',
+                    'start' => Carbon::parse($appointment->appointment_date),
+                ]));
+            });
+
+        return $blocks->sortBy('start')->values();
     }
 
     /**

--- a/resources/views/agenda/daily-schedule-print.blade.php
+++ b/resources/views/agenda/daily-schedule-print.blade.php
@@ -19,6 +19,7 @@
     .pdf-badge--attended { background: #d1fae5; color: #065f46; }
     .pdf-badge--cancelled { background: #fee2e2; color: #991b1b; }
     .pdf-badge--absent { background: #e5e7eb; color: #374151; }
+    .pdf-badge--available { background: #e5e7eb; color: #6b7280; }
 </style>
 @endif
 @endpush
@@ -116,7 +117,7 @@
             @endif
 
             <!-- Tabla de Turnos -->
-            @if($reportData['appointments']->count() > 0)
+            @if($reportData['schedule_blocks']->count() > 0)
             <div class="mb-2 print:mb-0.5">
                 <h5 class="report-section-title">Turnos del Día ({{ $reportData['appointments']->count() }})</h5>
                 <div class="overflow-x-auto">
@@ -130,16 +131,24 @@
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-gray-200 dark:divide-gray-700 print:divide-gray-400">
-                            @foreach($reportData['appointments'] as $appointment)
+                            @foreach($reportData['schedule_blocks'] as $block)
+                            @if($block['type'] === 'occupied')
                             <tr>
-                                <td class="py-[1px] px-1 text-center font-bold text-gray-900 dark:text-white print:text-black">{{ $appointment['time'] }}</td>
+                                <td class="py-[1px] px-1 text-center font-bold text-gray-900 dark:text-white print:text-black">
+                                    @if($block['is_urgency'])
+                                        <span title="Urgencia">🚨</span>
+                                    @elseif($block['is_between_turn'])
+                                        <span title="EntreTurno">⏱️</span>
+                                    @endif
+                                    {{ $block['time'] }}
+                                </td>
                                 <td class="py-[1px] px-1">
-                                    <span class="font-semibold text-gray-900 dark:text-white print:text-black">{{ $appointment['patient_name'] }}</span>
+                                    <span class="font-semibold text-gray-900 dark:text-white print:text-black">{{ $block['patient_name'] }}</span>
                                     <br>
                                     <span class="text-[9px] text-gray-500 dark:text-gray-400 print:text-gray-600">
-                                        DNI: {{ $appointment['patient_dni'] }}
-                                        @if($appointment['patient_insurance'])
-                                            | {{ $appointment['patient_insurance'] }}
+                                        DNI: {{ $block['patient_dni'] }}
+                                        @if($block['patient_insurance'])
+                                            | {{ $block['patient_insurance'] }}
                                         @endif
                                     </span>
                                 </td>
@@ -151,16 +160,30 @@
                                             'cancelled' => 'bg-red-100 text-red-800 print:bg-red-50 print:text-red-900',
                                             'absent'    => 'bg-gray-100 text-gray-700 print:bg-gray-50 print:text-gray-800',
                                         ];
-                                        $cls = $statusClasses[$appointment['status']] ?? 'bg-gray-100 text-gray-700';
+                                        $cls = $statusClasses[$block['status']] ?? 'bg-gray-100 text-gray-700';
                                     @endphp
-                                    <span class="inline-block px-1 py-0.5 rounded text-[8px] font-bold uppercase {{ $cls }} pdf-badge pdf-badge--{{ $appointment['status'] }}">
-                                        {{ $appointment['status_label'] }}
+                                    <span class="inline-block px-1 py-0.5 rounded text-[8px] font-bold uppercase {{ $cls }} pdf-badge pdf-badge--{{ $block['status'] }}">
+                                        {{ $block['status_label'] }}
                                     </span>
                                 </td>
                                 <td class="py-[1px] px-1 text-[9px] text-gray-700 dark:text-gray-300 print:text-gray-700">
-                                    {{ $appointment['notes'] ?: '-' }}
+                                    {{ $block['notes'] ?: '-' }}
                                 </td>
                             </tr>
+                            @else
+                            <tr style="background-color: #f9fafb;">
+                                <td class="py-[1px] px-1 text-center font-bold text-gray-400 dark:text-gray-500 print:text-gray-500" style="background-color: #f9fafb;">
+                                    {{ $block['start']->format('H:i') }}
+                                </td>
+                                <td class="py-[1px] px-1 text-gray-400 dark:text-gray-500 print:text-gray-500" style="background-color: #f9fafb;" colspan="2">
+                                    <span class="inline-block px-1 py-0.5 rounded text-[8px] font-bold uppercase bg-gray-200 text-gray-500 print:bg-gray-200 print:text-gray-600 pdf-badge pdf-badge--available">
+                                        {{ $block['label'] }}
+                                    </span>
+                                    <span class="text-[9px]">({{ $block['start']->format('H:i') }} - {{ $block['end']->format('H:i') }})</span>
+                                </td>
+                                <td class="py-[1px] px-1 text-[9px] text-gray-400 dark:text-gray-500 print:text-gray-500" style="background-color: #f9fafb;">-</td>
+                            </tr>
+                            @endif
                             @endforeach
                         </tbody>
                     </table>


### PR DESCRIPTION
La planilla diaria impresa/PDF de turnos ahora intercala, además de los turnos tomados, los espacios libres según el módulo típico configurado para cada profesional (AppointmentSetting.default_duration_minutes). Un turno más corto que el módulo ocupa el módulo completo (se compensa el sobrante); los huecos entre bloques de horario partido (ej. almuerzo) no se muestran como disponibles. El listado pasa a ordenarse cronológicamente en vez de forzar las urgencias al principio, que ahora se marcan con una insignia en su horario real. La vista en pantalla no impresa no cambia.