### PR TITLE
Consultorio predeterminado por profesional

### DIFF
--- a/app/Http/Controllers/AgendaController.php
+++ b/app/Http/Controllers/AgendaController.php
@@ -33,7 +33,7 @@ class AgendaController extends Controller
         $startOfCalendar = $date->copy()->startOfWeek();
         $endOfCalendar = $date->copy()->endOfMonth()->endOfWeek();
 
-        $professionals = Professional::active()->with('specialty')->ordered()->get();
+        $professionals = Professional::active()->with(['specialty', 'defaultOffice'])->ordered()->get();
         $patients = Patient::where('activo', true)->orderBy('last_name')->orderBy('first_name')->get();
         $offices = Office::where('is_active', true)->orderBy('name')->get();
 

--- a/resources/views/agenda/partials/scripts.blade.php
+++ b/resources/views/agenda/partials/scripts.blade.php
@@ -125,6 +125,7 @@ document.addEventListener('alpine:init', () => {
             }
             if (professionalId) {
                 this.form.professional_id = professionalId.toString();
+                this.applyDefaultOffice(professionalId);
             }
 
             this.modalOpen = true;
@@ -135,10 +136,21 @@ document.addEventListener('alpine:init', () => {
             this.resetForm();
             this.clearAllErrors();
             if (date) this.form.appointment_date = date;
-            if (professionalId) this.form.professional_id = professionalId.toString();
+            if (professionalId) {
+                this.form.professional_id = professionalId.toString();
+                this.applyDefaultOffice(professionalId);
+            }
             if (time) this.form.appointment_time = time;
             if (duration) this.form.duration = duration;
             this.modalOpen = true;
+        },
+
+        // Autocompletar consultorio predeterminado del profesional (si el campo está vacío)
+        applyDefaultOffice(professionalId) {
+            const professional = this.professionals.find(p => p.id == professionalId);
+            if (professional && professional.default_office && !this.form.office_id) {
+                this.form.office_id = professional.default_office.id.toString();
+            }
         },
 
         resetForm() {
@@ -655,6 +667,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const alpineComponent = Alpine.$data(document.querySelector('[x-data="appointmentModal()"]'));
                 if (alpineComponent) {
                     alpineComponent.form.professional_id = selectedValue;
+                    // Autocompletar consultorio predeterminado del profesional (si el campo está vacío)
+                    const selectedProfessional = alpineComponent.professionals.find(p => p.id == selectedValue);
+                    if (selectedProfessional && selectedProfessional.default_office && !alpineComponent.form.office_id) {
+                        alpineComponent.form.office_id = selectedProfessional.default_office.id.toString();
+                    }
                 }
             });
 

--- a/resources/views/appointments/index.blade.php
+++ b/resources/views/appointments/index.blade.php
@@ -1276,6 +1276,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const alpineComponent = Alpine.$data(document.querySelector('[x-data="appointmentsPage()"]'));
                 if (alpineComponent) {
                     alpineComponent.form.professional_id = selectedValue;
+                    // Autocompletar consultorio predeterminado del profesional (si el campo está vacío)
+                    const selectedProfessional = alpineComponent.professionals.find(p => p.id == selectedValue);
+                    if (selectedProfessional && selectedProfessional.default_office && !alpineComponent.form.office_id) {
+                        alpineComponent.form.office_id = selectedProfessional.default_office.id.toString();
+                    }
                 }
             });
 

--- a/resources/views/dashboard/dashboard.blade.php
+++ b/resources/views/dashboard/dashboard.blade.php
@@ -380,6 +380,11 @@ function urgencyModalDashboard() {
 
                             urgencyProfessionalSelect.on('change', function(e) {
                                 self.urgencyForm.professional_id = $(this).val();
+                                // Autocompletar consultorio predeterminado del profesional (si el campo está vacío)
+                                const selectedProfessional = self.professionals.find(p => p.id == self.urgencyForm.professional_id);
+                                if (selectedProfessional && selectedProfessional.default_office && !self.urgencyForm.office_id) {
+                                    self.urgencyForm.office_id = selectedProfessional.default_office.id.toString();
+                                }
                             });
 
                             urgencyProfessionalSelect.on('select2:open', function() {


### PR DESCRIPTION
## Resumen

- Cada profesional puede tener asignado un **consultorio predeterminado** (opcional, no obligatorio) desde el formulario de Profesionales (`professionals/modal.blade.php`), guardado en la nueva columna `default_office_id` de `professionals`.
- Al elegir un profesional en el formulario de turnos, el **consultorio se autocompleta** con su predeterminado si el campo todavía está vacío (no pisa una elección manual ya hecha). Aplica en:
  - Turnos (`/appointments`)
  - Agenda (`/agenda`), tanto desde el botón "Nuevo Turno" como al hacer clic en un espacio libre de la grilla
  - Modal de urgencia del Dashboard ("entre turno")
- Fix incluido en la misma rama: el autoseteo inicial (agregado como `@change` en el `<select>` nativo) no corría en la práctica porque las tres vistas usan **Select2**, cuya sincronización hacia Alpine usa `jQuery.trigger('change')` — que no dispara los listeners `addEventListener` de Alpine. Se movió la lógica al handler de sync de Select2 en cada vista, y se agregó el mismo tratamiento a la apertura directa del modal desde Agenda (que precompleta el profesional sin pasar por ningún select).
- Versión: bump patch `2.12.10` → `2.12.11` (cambio menor, se mantiene la convención de la serie 2.12.x), con entrada en `CHANGELOG.md`.

## Cambios técnicos

- Migración: `default_office_id` (nullable, FK a `offices`, `nullOnDelete`) en `professionals`.
- `Professional::defaultOffice()` (belongsTo `Office`).
- `ProfessionalController`: eager-load de `defaultOffice`, validación `nullable|exists:offices,id` en `store`/`update`.
- `AppointmentController` y `AgendaController`: eager-load de `defaultOffice` en la carga de profesionales usada por los formularios de turnos.
- Vistas: nuevo select "Consultorio predeterminado" en el modal de Profesionales; autoseteo de `office_id` en los handlers de sync de Select2 de Turnos, Agenda y el modal de urgencia del Dashboard, y en `openCreateModal`/`openCreateModalWithTime` de Agenda.

## Plan de pruebas

- [ ] `php artisan migrate` corre sin errores y crea `default_office_id` en `professionals`.
- [ ] En `/professionals`, asignar un consultorio predeterminado opcional a un profesional, guardar y reabrir el modal de edición para confirmar que persiste.
- [ ] En `/appointments`, "Nuevo Turno", elegir ese profesional **vía el dropdown de Select2** → el consultorio se autocompleta.
- [ ] En `/agenda`, usar el botón "Nuevo Turno" del panel del día y un clic en un espacio libre de la grilla → el consultorio viene precargado.
- [ ] Desde el Dashboard, modal de urgencia, elegir el profesional vía Select2 → se autocompleta.
- [ ] En los cuatro flujos: si el usuario ya eligió un consultorio manualmente, no se pisa al cambiar de profesional.
- [ ] Un profesional sin consultorio predeterminado deja el campo vacío sin bloquear el guardado.

No se pudo correr `php artisan migrate` ni probar en navegador en el entorno de desarrollo remoto (`composer install` no completó, posible bloqueo de red/proxy) — pendiente de verificación manual en local.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RyZLukeL4HArsUShf7Fs8k)_